### PR TITLE
Fixes Issue #28 String "null" appearance

### DIFF
--- a/src/main/java/net/sf/rails/game/PrivateCompany.java
+++ b/src/main/java/net/sf/rails/game/PrivateCompany.java
@@ -89,8 +89,8 @@ public class PrivateCompany extends RailsOwnableItem<PrivateCompany> implements 
     private String longName;
     private String alias;
     private CompanyType type;
-    private String infoText;
-    private String parentInfoText;
+    private String infoText = "";
+    private String parentInfoText ="";
     private final BooleanState closed = BooleanState.create(this, "closed", false);
     
     // used for Certificate interface

--- a/src/main/java/net/sf/rails/game/PublicCompany.java
+++ b/src/main/java/net/sf/rails/game/PublicCompany.java
@@ -297,8 +297,8 @@ public class PublicCompany extends RailsAbstractItem implements Company, RailsMo
     private String longName;
     private String alias;
     private CompanyType type;
-    private String infoText;
-    private String parentInfoText;
+    private String infoText ="";
+    private String parentInfoText ="";
     private final BooleanState closed = BooleanState.create(this, "closed", false);
     
     /**


### PR DESCRIPTION
Fixes Issue #28 Fixing the apperance of the String null in the infotext on Private andPublic Companies where it didnt belong, stemming from the use of
uninitialised variables.