### PR TITLE
Fixing setBuyableShares for multi share Certs

### DIFF
--- a/src/main/java/net/sf/rails/game/OperatingRound.java
+++ b/src/main/java/net/sf/rails/game/OperatingRound.java
@@ -2006,6 +2006,7 @@ public class OperatingRound extends Round implements Observer {
                         Currency.toBank(company, cost);
                 text.append(LocalText.getText("LAYS_TOKEN_ON", companyName,
                                 hex.getId(), costText));
+                text.append(stop.toText());
             } else {
                 text.append(LocalText.getText("LAYS_FREE_TOKEN_ON",
                         companyName, hex.getId()));

--- a/src/main/java/net/sf/rails/game/financial/StockRound.java
+++ b/src/main/java/net/sf/rails/game/financial/StockRound.java
@@ -263,7 +263,7 @@ public class StockRound extends Round {
 
                 if (!cert.isPresidentShare()) {
                     price = comp.getIPOPrice() / unitsForPrice;
-                    if (price <= playerCash) {
+                    if ((price*shares) <= playerCash) {
                         possibleActions.add(new BuyCertificate(comp, cert.getShare(),
                                 from.getParent(), price));
                     }

--- a/src/main/java/net/sf/rails/game/financial/StockRound.java
+++ b/src/main/java/net/sf/rails/game/financial/StockRound.java
@@ -230,7 +230,6 @@ public class StockRound extends Round {
             from = ipo;
             ImmutableSetMultimap<PublicCompany, PublicCertificate> map =
                 from.getCertsPerCompanyMap();
-            int shares;
 
             for (PublicCompany comp : map.keySet()) {
                 certs = map.get(comp);
@@ -259,11 +258,9 @@ public class StockRound extends Round {
                 if ((stockSpace == null || !stockSpace.isNoCertLimit()) && !mayPlayerBuyCertificate(
                         currentPlayer, comp, cert.getCertificateCount())) continue;
 
-                shares = cert.getShares();
-
                 if (!cert.isPresidentShare()) {
                     price = comp.getIPOPrice() / unitsForPrice;
-                    if ((price*shares) <= playerCash) {
+                    if ((price*cert.getShares()) <= playerCash) {
                         possibleActions.add(new BuyCertificate(comp, cert.getShare(),
                                 from.getParent(), price));
                     }
@@ -276,7 +273,7 @@ public class StockRound extends Round {
                     } else {
                         List<Integer> startPrices = new ArrayList<Integer>();
                         for (int startPrice : stockMarket.getStartPrices()) {
-                            if (startPrice * shares <= playerCash) {
+                            if (startPrice * cert.getShares()<= playerCash) {
                                 startPrices.add(startPrice);
                             }
                         }


### PR DESCRIPTION
Before this fix a cert with multiple shares was shown as buyable because
th price check did not account for multiple shares per cert. The buying
would have failed neverthe less. With this fix the price per shareunit 
in the price check is taking into account the multipe shares per cert if
they are present. This only works from the IPO currently. Theres a small
chance that the wrong display might appear on shares in the pool (but
very unlikely).
This is a fix for Issue #30 