### PR TITLE
Add oracle java 7 and openjdk 6 - 8 as testing java environments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,8 @@ addons:
 
 jdk:
   - oraclejdk8
-  - oraclejdk7
   - openjdk8
   - openjdk7
-  - openjdk6
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,15 @@ addons:
 
 jdk:
   - oraclejdk8
+  - oraclejdk7
+  - openjdk8
+  - openjdk7
+  - openjdk6
 
 branches:
   only:
   - rails_2_develop
+  - rails_2_maintenance
 
 before_install:
   - sudo apt-get update


### PR DESCRIPTION
In addition, add rails_2_maintanance branch to the testing branches.
This PR fixes #23.