### PR TITLE
Fix for a Bug in ShareSellingRound, automatic Bancruptcy Check is now

### DIFF
--- a/src/main/java/net/sf/rails/game/financial/ShareSellingRound.java
+++ b/src/main/java/net/sf/rails/game/financial/ShareSellingRound.java
@@ -54,7 +54,6 @@ public class ShareSellingRound extends StockRound {
         this.dumpOtherCompaniesAllowed = dumpOtherCompaniesAllowed;
         log.debug("Forced selling, dumpOtherCompaniesAllowed = " + dumpOtherCompaniesAllowed);
         getRoot().getPlayerManager().setCurrentPlayer(sellingPlayer);
-        //getSellableShares();
         if (getSellableShares().isEmpty()) {
             ReportBuffer.add(this, LocalText.getText("YouMustRaiseCashButCannot",
                     Bank.format(this, this.cashToRaise.value())));

--- a/src/main/java/net/sf/rails/game/financial/ShareSellingRound.java
+++ b/src/main/java/net/sf/rails/game/financial/ShareSellingRound.java
@@ -54,7 +54,15 @@ public class ShareSellingRound extends StockRound {
         this.dumpOtherCompaniesAllowed = dumpOtherCompaniesAllowed;
         log.debug("Forced selling, dumpOtherCompaniesAllowed = " + dumpOtherCompaniesAllowed);
         getRoot().getPlayerManager().setCurrentPlayer(sellingPlayer);
-        getSellableShares();
+        //getSellableShares();
+        if (getSellableShares().isEmpty()) {
+            ReportBuffer.add(this, LocalText.getText("YouMustRaiseCashButCannot",
+                    Bank.format(this, this.cashToRaise.value())));
+            DisplayBuffer.add(this, LocalText.getText("YouMustRaiseCashButCannot",
+                    Bank.format(this, this.cashToRaise.value())));
+            currentPlayer.setBankrupt();
+            gameManager.registerBankruptcy();
+        }
     }
 
     @Override


### PR DESCRIPTION
done.

Fix for the bug reported by HansvanderDrift:
A director needing to finance a train in an emergency train buy, cant
act currently if he has zero shares to be sold in the ShareSellingRound
if he does not have sufficient cash to finance the train by himeself
without selling shares. Fixes #48 