### PR TITLE
Expand project name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <packaging>jar</packaging>
     <version>2.0-RC4</version>
 
-    <name>Rails</name>
+    <name>Rails (18xx)</name>
     <description>A Java playing aid for playing 18xx based games via email or in Hotseat mode.</description>
 
     <organization>

--- a/src/deb/control/control
+++ b/src/deb/control/control
@@ -1,4 +1,4 @@
-Package: [[name]]
+Package: rails-18xx
 Version: [[version]]
 Section: games
 Priority: optional

--- a/src/scripts/rails-18xx.desktop
+++ b/src/scripts/rails-18xx.desktop
@@ -1,5 +1,5 @@
 [Desktop Entry]
-Name=Rails
+Name=Rails (18xx)
 Type=Application
 Exec=rails-18xx
 Icon=rails


### PR DESCRIPTION
This PR fixes the problem on debian based systems, that rails will be removed with the next update of "Ruby on Rails", because this package is also named `rails`.
In addition this PR expands the project name to `Rails (18xx)`.