### PR TITLE
Add version number

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,9 @@
         <jdk.version>1.8</jdk.version>
         <jarName.all>${project.build.finalName}-all</jarName.all>
         <launch4j.version>2.0.0.0</launch4j.version>
+
+        <timestamp>${maven.build.timestamp}</timestamp>
+        <maven.build.timestamp.format>yyyy-MM-dd</maven.build.timestamp.format>
     </properties>
 
     <dependencies>
@@ -154,6 +157,13 @@
     </dependencies>
 
     <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+
         <plugins>
             <!-- download source code in Eclipse, best practice -->
             <plugin>
@@ -281,6 +291,7 @@
                 </executions>
             </plugin>
 
+            <!-- Create a Debian deb installer -->
             <plugin>
                 <artifactId>jdeb</artifactId>
                 <groupId>org.vafer</groupId>

--- a/src/main/resources/build/version.number
+++ b/src/main/resources/build/version.number
@@ -1,8 +1,0 @@
-#Changes are only valid in the build subdirectory of src/main/resources
-#Property file that contains version number and the develop indicator
-version=2.0.RC3
-# the following string "@DEVELOP@" is replaced by an empty string in the release version
-# this is done automatically by gradle
-develop=@DEVELOP@
-# the following string "@ BUILDDATE @" is replaced by the build date
-buildDate=@BUILDDATE@

--- a/src/main/resources/version.number
+++ b/src/main/resources/version.number
@@ -1,8 +1,4 @@
-#Changes are only valid in the build subdirectory of src/main/resources
-#Property file that contains version number and the develop indicator
-version=2.0.RC3
-# the following string "" is replaced by an empty string in the release version
-# this is done automatically by gradle
-develop=
-# the following string "@ BUILDDATE @" is replaced by the build date
-buildDate=2017-07-09
+# the rails version
+version=${project.version}
+# the build date, when rails has been built
+buildDate=${timestamp}


### PR DESCRIPTION
This PR closes #27.

In addition this PR removes the `develop` field from the `version.number` file.
My belief is, that everyone who wants to work in development mode can add it locally to his file (for example for debugging purposes), otherwise rails should automatically assume that the user wants to run the application in release mode.