### PR TITLE
Fix for toArray error java.lang.ClassCastException for Java 11

### DIFF
--- a/src/main/java/net/sf/rails/ui/swing/ConfigWindow.java
+++ b/src/main/java/net/sf/rails/ui/swing/ConfigWindow.java
@@ -242,12 +242,12 @@ class ConfigWindow extends JFrame {
                 configValue = ((Font)UIManager.getDefaults().get("Label.font")).getFamily();
             }
         case LIST:
-            String[] allowedValues; 
+            String[] allowedValues = new String[1];
             if (item.type == ConfigItem.ConfigType.FONT) {
                 allowedValues = GraphicsEnvironment.getLocalGraphicsEnvironment().
                 getAvailableFontFamilyNames(); 
             } else {
-                allowedValues = (String[])item.allowedValues.toArray();
+                allowedValues = (String[])item.allowedValues.toArray(allowedValues);
             }
             final JComboBox<String> comboBox = new JComboBox<String>(allowedValues);
             comboBox.setSelectedItem(configValue);


### PR DESCRIPTION
I get this exception when running Rails on Java 11

Exception in thread "AWT-EventQueue-0" java.lang.ClassCastException: class [Ljava.lang.Object; cannot be cast to class [Ljava.lang.String; ([Ljava.lang.Object; and [Ljava.lang.String; are in module java.base of loader 'bootstrap')
	at net.sf.rails.ui.swing.ConfigWindow.defineElement(ConfigWindow.java:250)

With this fix that problem goes away.