### PR TITLE
reduce min on auto polling

### DIFF
--- a/src/main/java/net/sf/rails/ui/swing/AutoSaveLoadDialog.java
+++ b/src/main/java/net/sf/rails/ui/swing/AutoSaveLoadDialog.java
@@ -71,7 +71,7 @@ public class AutoSaveLoadDialog extends JDialog implements ActionListener {
         buttonPane.add(cancelButton);
 
         choiceButtons = new JRadioButton[3];
-        intervalSpinner = new Spinner (interval, 10, 0, 10);
+        intervalSpinner = new Spinner (interval, 3, 0, 1);
 
         getContentPane().setLayout(new GridBagLayout());
         setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);


### PR DESCRIPTION
Decrease the min polling interval as "real-time" play with 30 seconds is a very long time on top of the already long time of an 18xx game :)