### PR TITLE
windows learn to respect myTurn

### DIFF
--- a/src/main/java/net/sf/rails/ui/swing/ORUIManager.java
+++ b/src/main/java/net/sf/rails/ui/swing/ORUIManager.java
@@ -31,6 +31,7 @@ import net.sf.rails.game.Tile;
 import net.sf.rails.game.TrackConfig;
 import net.sf.rails.game.Train;
 import net.sf.rails.game.financial.ShareSellingRound;
+import net.sf.rails.game.round.RoundFacade;
 import net.sf.rails.game.special.SpecialProperty;
 import net.sf.rails.game.special.SpecialTileLay;
 import net.sf.rails.game.special.SpecialBaseTokenLay;
@@ -530,7 +531,6 @@ public class ORUIManager implements DialogOwner {
     }
 
     protected void setDividend(String command, SetDividend action) {
-
         int amount;
 
         if (command.equals(ORPanel.SET_REVENUE_CMD)) {
@@ -1281,22 +1281,23 @@ public class ORUIManager implements DialogOwner {
     /** Used to process some < properties from the 'Special' menu */
     /* In fact currently not used */
     protected void useSpecialProperty (UseSpecialProperty action) {
-
         gameUIManager.processAction(action);
-
     }
 
     public void updateStatus(boolean myTurn) {
-
         updateStatus(null, myTurn);
-
     }
 
     public void updateStatus(PossibleAction actionToComplete, boolean myTurn) {
-
         orPanel.resetActions();
 
         messagePanel.setMessage(null);
+
+        RoundFacade currentRound = gameUIManager.getCurrentRound();
+        if (!(currentRound instanceof OperatingRound)) {
+            log.debug("early return: {}", currentRound);
+            return;
+        }
 
         if (actionToComplete != null) {
             log.debug("ExecutedAction: {}", actionToComplete);
@@ -1304,7 +1305,7 @@ public class ORUIManager implements DialogOwner {
         // End of possible action debug listing
 
         PublicCompany orComp = oRound.getOperatingCompany();
-        log.debug("Or company = {} in round {}", orComp.getId(), oRound.getRoundName());
+        log.debug("OR company = {} in round {}", orComp.getId(), oRound.getRoundName());
 
         GameDef.OrStep orStep = oRound.getStep();
         log.debug("OR step={}", orStep);
@@ -1319,6 +1320,8 @@ public class ORUIManager implements DialogOwner {
         }
 
         orPanel.initORCompanyTurn(orComp, orCompIndex);
+
+        //orPanel.initPrivateBuying(false);
 
 
         if (!myTurn) return;

--- a/src/main/java/net/sf/rails/ui/swing/StartRoundWindow.java
+++ b/src/main/java/net/sf/rails/ui/swing/StartRoundWindow.java
@@ -14,6 +14,7 @@ import net.sf.rails.game.*;
 import net.sf.rails.game.financial.Bank;
 import net.sf.rails.game.financial.StockMarket;
 import net.sf.rails.game.financial.StockSpace;
+import net.sf.rails.game.round.RoundFacade;
 import net.sf.rails.game.special.SpecialProperty;
 import net.sf.rails.sound.SoundManager;
 import net.sf.rails.ui.swing.elements.*;
@@ -417,6 +418,17 @@ public class StartRoundWindow extends JFrame implements ActionListener, KeyListe
         }
         // Unselect the selected private
         dummyButton.setSelected(true);
+
+        buyButton.setEnabled(false);
+        bidButton.setEnabled(false);
+        bidAmount.setEnabled(false);
+        passButton.setEnabled(false);
+
+        RoundFacade currentRound = gameUIManager.getCurrentRound();
+        if (!(currentRound instanceof StartRound)) {
+            log.debug("early return: {}", currentRound);
+            return;
+        }
 
         if (!myTurn) return;
 

--- a/src/main/java/net/sf/rails/ui/swing/StatusWindow.java
+++ b/src/main/java/net/sf/rails/ui/swing/StatusWindow.java
@@ -26,6 +26,7 @@ import net.sf.rails.game.EndOfGameRound;
 import net.sf.rails.game.GameManager;
 import net.sf.rails.game.OperatingRound;
 import net.sf.rails.game.Player;
+import net.sf.rails.game.Round;
 import net.sf.rails.game.StartRound;
 import net.sf.rails.game.financial.ShareSellingRound;
 import net.sf.rails.game.financial.StockRound;
@@ -299,10 +300,6 @@ public class StatusWindow extends JFrame implements ActionListener, KeyListener,
         }
     }
 
-    public StatusWindow() {
-
-    }
-
     public void init(GameUIManager gameUIManager) {
         this.gameUIManager = gameUIManager;
         this.possibleActions = gameUIManager.getGameManager().getPossibleActions();
@@ -464,11 +461,14 @@ public class StatusWindow extends JFrame implements ActionListener, KeyListener,
     }
 
     public void updateStatus(boolean myTurn) {
+        passButton.setEnabled(false);
+        autopassButton.setEnabled(false);
 
-        if (!(currentRound instanceof StockRound || currentRound instanceof EndOfGameRound))
+        if (!(currentRound instanceof StockRound || currentRound instanceof EndOfGameRound)) {
+            log.debug("early return: {}", currentRound);
             return;
+        }
 
-        log.debug ("MyTurn="+myTurn);
         if (!myTurn) {
             gameStatus.initTurn(getCurrentPlayer().getIndex(), false);
             return;
@@ -479,7 +479,6 @@ public class StatusWindow extends JFrame implements ActionListener, KeyListener,
             immediateAction = possibleActions.getType(DiscardTrain.class).get(0);
             return;
         }
-
 
         if (currentRound instanceof TreasuryShareRound) {
             setTitle(LocalText.getText(
@@ -548,9 +547,6 @@ public class StatusWindow extends JFrame implements ActionListener, KeyListener,
         specialMenu.setOpaque(enabled);
         specialMenu.setEnabled(enabled);
         specialMenu.repaint();
-
-        passButton.setEnabled(false);
-        autopassButton.setEnabled(false);
 
         List<NullAction> inactiveItems =
             possibleActions.getType(NullAction.class);


### PR DESCRIPTION
There is currently a bug that a user, in auto-load/save mode, can click "pass" (for example) twice in a row, ending now only his turn but the next players turn.

This PR fixes up the disabling and enabling the controls based on whether a player is the active player. Note that due to the check for polling enabled this shouldn't affect a hot-seat or PBEM game (but note that I did not extensively test that either).

This also contains a bug fix that correctly sets the myTurn variable when a file is loaded