### PR TITLE
do not write config option to game file if empty

### DIFF
--- a/src/main/java/net/sf/rails/util/GameSaver.java
+++ b/src/main/java/net/sf/rails/util/GameSaver.java
@@ -10,6 +10,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -83,7 +84,7 @@ public class GameSaver {
                 for ( ConfigItem config : entry.getValue() ) {
                     if ( config.isGameRelated ) {
                         String value = Config.get(config.name);
-                        if ( value != null ) {
+                        if ( StringUtils.isNotBlank(value) ) {
                             gameOptions.put(config.name, Config.get(config.name));
                         }
                     }


### PR DESCRIPTION
Tweak the saving of game-play related config options to the game file by ignoring any option that is empty