### PR TITLE
issue with saving file name that doesn't match our expectations

### DIFF
--- a/src/main/java/net/sf/rails/ui/swing/GameUIManager.java
+++ b/src/main/java/net/sf/rails/ui/swing/GameUIManager.java
@@ -966,9 +966,9 @@ public class GameUIManager implements DialogOwner {
                 // Check the new name. If only the prefix has changed, only remember that part.
                 String[] proposedParts = proposedFile.getName().split("_", 2);
                 String[] selectedParts = selectedFile.getName().split("_", 2);
-                // TODO: fails if a user does something like test.rails
-                if (!proposedParts[0].equals(selectedParts[0])
-                        && proposedParts[1].equals(selectedParts[1])) {
+                if (proposedParts.length >= 2 && selectedParts.length >= 2 &&
+                        !proposedParts[0].equals(selectedParts[0]) &&
+                        proposedParts[1].equals(selectedParts[1])) {
                     savePrefix = selectedParts[0];
                 } else {
                     // Otherwise, remember and keep using the whole filename.


### PR DESCRIPTION
If a user picks a file name that doesn't match our expectations we throw an exception due to a NPE. This fixes that issue but does not verify whether there are any other places we have expectations regarding the file name format