### PR TITLE
poller should know of initially loaded file

### DIFF
--- a/src/main/java/net/sf/rails/ui/swing/GameUIManager.java
+++ b/src/main/java/net/sf/rails/ui/swing/GameUIManager.java
@@ -1038,7 +1038,7 @@ public class GameUIManager implements DialogOwner {
         }
 
         if (autoLoadPoller == null && autoSaveLoadStatus > 0) {
-            autoLoadPoller = new AutoLoadPoller (this, saveDirectory, savePrefix,
+            autoLoadPoller = new AutoLoadPoller (this, saveDirectory, savePrefix, lastSavedFilename,
                     localPlayerName, autoSaveLoadStatus, autoSaveLoadPollingInterval);
             autoLoadPoller.start();
         } else if (autoLoadPoller != null) {

--- a/src/main/java/net/sf/rails/util/GameLoader.java
+++ b/src/main/java/net/sf/rails/util/GameLoader.java
@@ -75,7 +75,6 @@ public class GameLoader {
 
         GameUIManager gameUIManager = startGameUIManager(gameLoader.getRoot(), true, splashWindow);
 
-        // TODO: Check if this is correct
         gameUIManager.setGameFile(gameFile);
 
         gameUIManager.startLoadedGame();


### PR DESCRIPTION
When a game is loaded and polling is enabled (either via the menu option or the saved configuration) the poller starts out not knowing the most previously loaded file and hence immediately attempts to (re)load the current file and passes it to the GameUIManager for loading which, for a long game, can take a bit. 

This PR initializes the poller with the most recently loaded file so it doesn't attempt to (re)load it. 