### PR TITLE
added developer menu to dump logs

### DIFF
--- a/src/main/java/net/sf/rails/ui/swing/StatusWindow.java
+++ b/src/main/java/net/sf/rails/ui/swing/StatusWindow.java
@@ -109,13 +109,13 @@ public class StatusWindow extends JFrame implements ActionListener, KeyListener,
     private JMenuBar menuBar;
 
     private static JMenu fileMenu, optMenu, moveMenu, moderatorMenu,
-    specialMenu, correctionMenu;
+    specialMenu, correctionMenu, developerMenu;
 
     private JMenuItem menuItem;
 
     private ActionMenuItem actionMenuItem;
 
-    private ActionMenuItem undoItem, forcedUndoItem, redoItem, redoItem2;
+    private ActionMenuItem undoItem, forcedUndoItem, redoItem, redoItem2, saveLogsItem;
 
     private static final Logger log =
             LoggerFactory.getLogger(StatusWindow.class);
@@ -292,6 +292,18 @@ public class StatusWindow extends JFrame implements ActionListener, KeyListener,
         // because menu is not
         // opaque
         menuBar.add(specialMenu);
+
+        if ( Config.getDevelop() ) {
+            developerMenu = new JMenu("Developer");
+            developerMenu.setName("Developer");
+            menuBar.add(developerMenu);
+
+            saveLogsItem = new ActionMenuItem("Save Logs");
+            saveLogsItem.setName("Save Logs");
+            saveLogsItem.setActionCommand("Save Logs");
+            saveLogsItem.addActionListener(this);
+            developerMenu.add(saveLogsItem);
+        }
 
         setJMenuBar(menuBar);
 
@@ -660,6 +672,8 @@ public class StatusWindow extends JFrame implements ActionListener, KeyListener,
             gameUIManager.autoSaveLoadGame();
         } else if (command.equals(SAVESTATUS_CMD)) {
             gameUIManager.saveGameStatus();
+        } else if ( command.equals("Save Logs")) {
+            gameUIManager.saveLogs();
         } else if (executedAction == null) {
             ;
         } else if (executedAction instanceof GameAction) {

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -15,10 +15,21 @@
         </encoder>
     </appender>
 
+    <appender name="buffer" class="ch.qos.logback.core.read.CyclicBufferAppender">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>DEBUG</level>
+        </filter>
+        <MaxSize>1024</MaxSize>
+        <encoder>
+            <pattern>%d{MM-dd-yyyy:HH:mm:ss.SSS} [%thread] %-5level %logger{10}->%method\(\):%line - %msg%n</pattern>
+        </encoder>
+    </appender>
+
     <logger name="net.sf.rails.algorithms" level="WARN"/>
 
     <root level="DEBUG">
         <appender-ref ref="stdout" />
         <appender-ref ref="file" />
+        <appender-ref ref="buffer" />
     </root>
 </configuration>


### PR DESCRIPTION
This PR added a developer menu to trigger a dump of the last 1,000 log files into a file where the saved game file exists.

We have been using this while playing auto-load/save games with a shared folder to dump the logs when one of the players runs into an issue. The log file is then named and written next to the currently/previously loaded game file.