### PR TITLE
fixed logback configuration error

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -20,9 +20,6 @@
             <level>DEBUG</level>
         </filter>
         <MaxSize>1024</MaxSize>
-        <encoder>
-            <pattern>%d{MM-dd-yyyy:HH:mm:ss.SSS} [%thread] %-5level %logger{10}->%method\(\):%line - %msg%n</pattern>
-        </encoder>
     </appender>
 
     <logger name="net.sf.rails.algorithms" level="WARN"/>


### PR DESCRIPTION
Removed encoder and pattern as they are not used by the cyclic buffer. This removes an error during app startup that causes the dump of logback init details