### PR TITLE
reduce logging level for stdout

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
     <appender name="stdout" class="ch.qos.logback.core.ConsoleAppender">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>INFO</level>
+        </filter>
         <encoder>
             <pattern>%d{HH:mm:ss.SSS} - %msg%n</pattern>
         </encoder>


### PR DESCRIPTION
Reduced the output to stdout to 1) improve performance as we aren't writing lots of data to the console if a user starts from the command line and 2) cleans up developer level information leaving just key/important details on the console for the user.

This leaves in place logging debug level to the log file