### PR TITLE
new game w/poller enabled should ask to save file

### DIFF
--- a/src/main/java/net/sf/rails/ui/swing/GameSetupController.java
+++ b/src/main/java/net/sf/rails/ui/swing/GameSetupController.java
@@ -176,16 +176,15 @@ public class GameSetupController {
 
             String startError = railsRoot.start();
             if (startError != null) {
-                JOptionPane.showMessageDialog(window, startError, "",
-                        JOptionPane.ERROR_MESSAGE);
+                JOptionPane.showMessageDialog(window, startError, "", JOptionPane.ERROR_MESSAGE);
                 System.exit(-1);
             }
             prepareGameUIInit();
             gameUIManager = GameLoader.startGameUIManager (railsRoot, false, splashWindow);
             gameUIManager.gameUIInit(true); // true indicates new game
 
-            gameUIManager.notifyOfSplashFinalization();
             splashWindow.finalizeGameInit();
+            gameUIManager.notifyOfSplashFinalization();
         }
     }
 

--- a/src/main/java/net/sf/rails/util/GameLoader.java
+++ b/src/main/java/net/sf/rails/util/GameLoader.java
@@ -81,10 +81,10 @@ public class GameLoader {
         GameUIManager gameUIManager = startGameUIManager(gameLoader.getRoot(), true, splashWindow);
 
         gameUIManager.setGameFile(gameFile);
-
         gameUIManager.startLoadedGame();
-        gameUIManager.notifyOfSplashFinalization();
+
         splashWindow.finalizeGameInit();
+        gameUIManager.notifyOfSplashFinalization();
     }
 
     public static GameUIManager startGameUIManager(RailsRoot game, boolean wasLoaded, SplashWindow splashWindow) {


### PR DESCRIPTION
Currently when auto-load/save is enabled automatically via user configuration the user still has to:
* Save the game for the first time (especially important if they are not the first player!)

In addition, polling isn't automatically enabled because that game file is saved *after* polling had it's change to initialize.

And finally the UI is not enabled/disabled appropriately if the first user is not the user that started the game (instead the UI is left enabled, ie the "default" state).

This PR addresses all of these issues by:
* Forcing a save of the game after the the UI has completed it's initial initialization
* Enabling polling by moving initialization to after the UI's initialization is complete (and hence it can then also trigger the forced save)
* Set the myTurn variable appropriate so that when the UI is drawn for the first time it is enabled/disabled correctly.