### PR TITLE
fix quit issue on Mac

### DIFF
--- a/src/main/java/net/sf/rails/ui/swing/StatusWindow.java
+++ b/src/main/java/net/sf/rails/ui/swing/StatusWindow.java
@@ -321,7 +321,7 @@ public class StatusWindow extends JFrame implements ActionListener, KeyListener,
                 Class.forName(gameStatusClassName).asSubclass(GameStatus.class);
             gameStatus = gameStatusClass.newInstance();
         } catch (Exception e) {
-            log.error("Cannot instantiate class " + gameStatusClassName, e);
+            log.error("Cannot instantiate class {}", gameStatusClassName, e);
             System.exit(1);
         }
 
@@ -385,6 +385,26 @@ public class StatusWindow extends JFrame implements ActionListener, KeyListener,
                 guiMgr.getWindowSettings().set(frame);
             }
         });
+
+        if ( Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported(Desktop.Action.APP_QUIT_HANDLER) ) {
+            Desktop.getDesktop().setQuitHandler((e, r) -> {
+                if ( JOptionPane.showConfirmDialog(frame, LocalText.getText("CLOSE_WINDOW"), LocalText.getText("Select"), JOptionPane.OK_CANCEL_OPTION) == JOptionPane.OK_OPTION ) {
+                    frame.dispose();
+                    guiMgr.terminate();
+                    r.performQuit();
+                }
+                else {
+                    r.cancelQuit();
+                }
+            });
+        }
+
+//        SwingUtilities.invokeLater(() -> {
+//            JFrame main = new JFrame("java.awt.Desktop");
+//            main.setSize(new Dimension(600, 400));
+//            main.setLocationRelativeTo(null);
+//            main.setVisible(true);
+//        });
 
         gameUIManager.packAndApplySizing(this);
     }


### PR DESCRIPTION
If a user uses the OS File menu to quit Rails (vs the menu inside of the Status window) it by-passes the termination logic we have in place (which, for example, saves off current window sizes and locations). This PR fixes that by added a event handler for `Desktop` events (which may also be generated on other platforms FYI.

This also removes the dummy desktop window created (which needs confirmation it does not cause any issues on Linux and Windows as I've confirmed it continues to be fine on the Mac).