### PR TITLE
load game file filter needs a name

### DIFF
--- a/src/main/java/net/sf/rails/ui/swing/GameSetupController.java
+++ b/src/main/java/net/sf/rails/ui/swing/GameSetupController.java
@@ -219,9 +219,10 @@ public class GameSetupController {
 
                 @Override
                 public String getDescription() {
-                    return null;
+                    return "Rails files";
                 }
             });
+            jfc.setAcceptAllFileFilterUsed(false);
 
             if (jfc.showOpenDialog(window.getContentPane()) == JFileChooser.APPROVE_OPTION) {
                 final File selectedFile = jfc.getSelectedFile();


### PR DESCRIPTION
Tweak to the load saved game file dialog to display a name for file types being displayed and to disable selecting any (non-rails) game files