### PR TITLE
enable support for double clicking saved game/last rails on Mac

### DIFF
--- a/src/main/java/net/sf/rails/ui/swing/GameUIManager.java
+++ b/src/main/java/net/sf/rails/ui/swing/GameUIManager.java
@@ -105,7 +105,7 @@ public class GameUIManager implements DialogOwner {
     protected static final String DEFAULT_SAVE_PATTERN = "yyyyMMdd_HHmm";
     public static final String DEFAULT_SAVE_EXTENSION = "rails";
 
-    public static final String DEFAULT_SAVE_POLLING_EXTENSION = "last_rails";
+    public static final String DEFAULT_SAVE_POLLING_EXTENSION = "lrails";
     protected static final String NEXT_PLAYER_SUFFIX = "NEXT_PLAYER";
     protected static final String CURRENT_ROUND_SUFFIX = "CURRENT_ROUND";
 

--- a/src/main/java/net/sf/rails/util/RunGame.java
+++ b/src/main/java/net/sf/rails/util/RunGame.java
@@ -1,38 +1,54 @@
 package net.sf.rails.util;
 
+import java.awt.*;
+import java.awt.desktop.OpenFilesEvent;
+import java.awt.desktop.OpenFilesHandler;
 import java.io.File;
 
+import javax.swing.*;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import net.sf.rails.common.ConfigManager;
+import net.sf.rails.ui.swing.AutoSaveLoadDialog;
 import net.sf.rails.ui.swing.GameSetupController;
 
 public class RunGame {
 
-    public static void main(String[] args) {
+    private static final Logger log = LoggerFactory.getLogger(RunGame.class);
 
-        // Initialize configuration
-        ConfigManager.initConfiguration(false);
-        
-        int nargs = 0;
+    public static void main(String[] args) {
+        final String[] fileName = { null };
+
         if (args != null && args.length > 0) {
-            nargs = args.length;
-            System.out.println("Number of args: "+nargs);
             for (String arg : args) {
                 System.out.println ("Arg: "+arg);
             }
+            fileName[0] = args[0];
         }
 
+        if ( Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported(Desktop.Action.APP_OPEN_FILE)) {
+            Desktop.getDesktop().setOpenFileHandler(e -> {
+                for ( File file : e.getFiles() ) {
+                    // open the file
+                    fileName[0] = file.toString();
+                    // break out as we only handle one game at a time...
+                    break;
+                }
+            });
+        }
+
+        // Initialize configuration
+        ConfigManager.initConfiguration(false);
+
         // currently we only start one game
-        if (nargs >= 1) {
-            loadGame(args[0]);
+        if ( fileName[0] != null ) {
+            GameLoader.loadAndStartGame(new File(fileName[0]));
         } else {
             /* Start the rails.game selector, which will do all the rest. */
             GameSetupController.Builder setupBuilder = GameSetupController.builder();
             setupBuilder.start();
         }
-    }
-
-    private static void loadGame (String filePath) {
-        File gameFile = new File(filePath);
-        GameLoader.loadAndStartGame(gameFile);
     }
 }

--- a/src/main/resources/build/last_rails-osx-association.properties
+++ b/src/main/resources/build/last_rails-osx-association.properties
@@ -1,4 +1,4 @@
-extension=last_rails
+extension=lrails
 mime-type=application/rails-18xx-last
 icon=./src/main/resources/images/icon/last_rails.icns
 description=Rails polling file


### PR DESCRIPTION
Enables support for handling a double click of a saved game (or last rails) file on a Mac.

May also work on Windows and Linux (but don't have those platforms to test)

Renamed the `.last_rails` file to `.lrails` due to Mac not liking the `_` in the file extension (it doesn't seem to recognize the file association). There was an open question in Slack regarding the file extension but no decision so I just went with this to get the PR out