### PR TITLE
small syntax fix for release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,8 @@ name: Create Releases with Gradle
 
 on:
   push:
-    tags: releases/*
+    tags:
+      - 'releases/*'
 
 jobs:
   jdk11:


### PR DESCRIPTION
A small syntax fix because the tags need to be a list, not a string. Woops.

(see: https://github.com/actions/create-release#example-workflow---create-a-release )