### PR TITLE
remove RailsRoot static instance

### DIFF
--- a/src/main/java/net/sf/rails/algorithms/NetworkGraphModifier.java
+++ b/src/main/java/net/sf/rails/algorithms/NetworkGraphModifier.java
@@ -1,29 +1,32 @@
 package net.sf.rails.algorithms;
 
 import net.sf.rails.game.PublicCompany;
+import net.sf.rails.game.RailsRoot;
 
 /**
  * Classes that change properties of the network graph
  * before both route evaluation and revenenue calculation starts
  * implement this interface.
- *  
+ *
  * They have to register themselves to the RevenueManager (via declaration in Game.xml or by code)
- * 
+ *
  * TODO: It is possible to merge both methods if required
  */
 
 public interface NetworkGraphModifier {
 
+    void setRoot(RailsRoot root);
+
     /**
      * General modification of the map graph (for all situations and companies)
      * @param mapGraph reference to the map graph
      */
-    public void modifyMapGraph(NetworkGraph mapGraph);
-    
+    void modifyMapGraph(NetworkGraph mapGraph);
+
     /**
      * Modification of the route graph for a specific company
      * @param mapGraph reference to the map graph
      */
-    public void modifyRouteGraph(NetworkGraph mapGraph, PublicCompany company);
-    
+    void modifyRouteGraph(NetworkGraph mapGraph, PublicCompany company);
+
 }

--- a/src/main/java/net/sf/rails/algorithms/RevenueManager.java
+++ b/src/main/java/net/sf/rails/algorithms/RevenueManager.java
@@ -71,7 +71,9 @@ public final class RevenueManager extends RailsManager implements Configurable {
                 boolean isModifier = false;
                 // add them to the revenueManager
                 if (modifier instanceof NetworkGraphModifier) {
-                    graphModifiers.add((NetworkGraphModifier) modifier);
+                    NetworkGraphModifier ngm = (NetworkGraphModifier) modifier;
+                    ngm.setRoot(getRoot());
+                    graphModifiers.add(ngm);
                     isModifier = true;
                     log.debug("Added as graph modifier = {}", className);
                 }

--- a/src/main/java/net/sf/rails/common/Config.java
+++ b/src/main/java/net/sf/rails/common/Config.java
@@ -87,8 +87,8 @@ public final class Config {
     /**
      * Configuration option: First tries to return {key}.{gameName}, if undefined returns {key}
      */
-    public static String getGameSpecific(String key) {
-        return getSpecific(key, RailsRoot.getInstance().getGameName());
+    public static String getGameSpecific(String gameName, String key) {
+        return getSpecific(key, gameName);
     }
 
     public static String getRecent(String key) {

--- a/src/main/java/net/sf/rails/game/Bonus.java
+++ b/src/main/java/net/sf/rails/game/Bonus.java
@@ -41,7 +41,7 @@ public class Bonus implements Closeable, RevenueStaticModifier {
         this.locations = locations;
 
         // add them to the call list of the RevenueManager
-        RailsRoot.getInstance().getRevenueManager().addStaticModifier(this);
+       owner.getRoot().getRevenueManager().addStaticModifier(this);
 
     }
     public boolean isExecutionable() {
@@ -84,7 +84,7 @@ public class Bonus implements Closeable, RevenueStaticModifier {
      * See prepareForRemovel().
      */
     public void close() {
-        RailsRoot.getInstance().getRevenueManager().removeStaticModifier(this);
+        owner.getRoot().getRevenueManager().removeStaticModifier(this);
     }
 
 

--- a/src/main/java/net/sf/rails/game/GameManager.java
+++ b/src/main/java/net/sf/rails/game/GameManager.java
@@ -155,13 +155,20 @@ public class GameManager extends RailsManager implements Configurable, Owner {
     protected Map<String, Object> objectStorage = new HashMap<>();
     protected Map<String, Integer> storageIds = new HashMap<>();
 
-    private static int revenueSpinnerIncrement = 10;
+    private int revenueSpinnerIncrement = 10;
     //Used for Storing the PublicCompany to be Founded by a formationround
     private PublicCompany nationalToFound;
 
     private final Map<PublicCompany, Player> NationalFormStartingPlayer = new HashMap<>();
 
     protected PlayerOrderModel playerNamesModel;
+
+    /**
+     * @return the revenueSpinnerIncrement
+     */
+    public int getRevenueSpinnerIncrement() {
+        return revenueSpinnerIncrement;
+    }
 
     public GameManager(RailsRoot parent, String id) {
         super(parent, id);
@@ -425,10 +432,6 @@ public class GameManager extends RailsManager implements Configurable, Owner {
 
     public PossibleActions getPossibleActions() {
         return possibleActions;
-    }
-
-    public static int getRevenueSpinnerIncrement() {
-        return revenueSpinnerIncrement;
     }
 
     protected void setGuiParameters() {
@@ -749,13 +752,13 @@ public class GameManager extends RailsManager implements Configurable, Owner {
 
         // Add the Undo/Redo possibleActions here.
         if (changeStack.isUndoPossible(getCurrentPlayer())) {
-            possibleActions.add(new GameAction(GameAction.Mode.UNDO));
+            possibleActions.add(new GameAction(getRoot(), GameAction.Mode.UNDO));
         }
         if (changeStack.isUndoPossible()) {
-            possibleActions.add(new GameAction(GameAction.Mode.FORCED_UNDO));
+            possibleActions.add(new GameAction(getRoot(), GameAction.Mode.FORCED_UNDO));
         }
         if (changeStack.isRedoPossible()) {
-            possibleActions.add(new GameAction(GameAction.Mode.REDO));
+            possibleActions.add(new GameAction(getRoot(), GameAction.Mode.REDO));
         }
 
         // logging of game actions activated
@@ -844,7 +847,6 @@ public class GameManager extends RailsManager implements Configurable, Owner {
     }
 
     public boolean processOnReload(PossibleAction action) {
-
         getRoot().getReportManager().getDisplayBuffer().clear();
 
         // TEMPORARY FIX TO ALLOW OLD 1856 SAVED FILES TO BE PROCESSED
@@ -856,7 +858,7 @@ public class GameManager extends RailsManager implements Configurable, Owner {
                 && ((NullAction) action).getMode() != NullAction.Mode.DONE))) {
             // Insert "Done"
             log.debug("Action DONE inserted");
-            getCurrentRound().process(new NullAction(NullAction.Mode.DONE));
+            getCurrentRound().process(new NullAction(getRoot(), NullAction.Mode.DONE));
             possibleActions.clear();
             getCurrentRound().setPossibleActions();
             if (!isGameOver()) setCorrectionActions();
@@ -962,7 +964,7 @@ public class GameManager extends RailsManager implements Configurable, Owner {
         GameLoader gameLoader = new GameLoader();
         String filepath = reloadAction.getFilepath();
 
-        if (!gameLoader.reloadGameFromFile(new File(filepath))) {
+        if (!gameLoader.reloadGameFromFile(getRoot(), new File(filepath))) {
             return false;
         }
 

--- a/src/main/java/net/sf/rails/game/OperatingRound.java
+++ b/src/main/java/net/sf/rails/game/OperatingRound.java
@@ -458,13 +458,13 @@ public class OperatingRound extends Round implements Observer {
                 // lay
                 // I am not sure that this will work with multiple home hexes.
                 for (MapHex home : operatingCompany.value().getHomeHexes()) {
-                    possibleActions.add(new LayBaseToken(home));
+                    possibleActions.add(new LayBaseToken(getRoot(), home));
                 }
                 forced = true;
             } else {
                 possibleActions.addAll(getNormalTileLays(true));
                 possibleActions.addAll(getSpecialTileLays(true));
-                possibleActions.add(new NullAction(NullAction.Mode.SKIP));
+                possibleActions.add(new NullAction(getRoot(), NullAction.Mode.SKIP));
             }
 
         } else if (step == GameDef.OrStep.LAY_TOKEN) {
@@ -475,7 +475,7 @@ public class OperatingRound extends Round implements Observer {
 
             possibleActions.addAll(currentNormalTokenLays);
             possibleActions.addAll(currentSpecialTokenLays);
-            possibleActions.add(new NullAction(NullAction.Mode.SKIP));
+            possibleActions.add(new NullAction(getRoot(), NullAction.Mode.SKIP));
         } else if (step == GameDef.OrStep.CALC_REVENUE) {
             prepareRevenueAndDividendAction();
             if (noMapMode) prepareNoMapActions();
@@ -524,8 +524,7 @@ public class OperatingRound extends Round implements Observer {
                 int minPrice, maxPrice;
                 List<Player> players = playerManager.getPlayers();
                 int numberOfPlayers = playerManager.getNumberOfPlayers();
-                for (int i = currentPlayerIndex; i < currentPlayerIndex
-                        + numberOfPlayers; i++) {
+                for (int i = currentPlayerIndex; i < currentPlayerIndex + numberOfPlayers; i++) {
                     player = players.get(i % numberOfPlayers);
                     if (!maySellPrivate(player)) continue;
                     for (PrivateCompany privComp : player.getPortfolioModel().getPrivateCompanies()) {
@@ -549,8 +548,7 @@ public class OperatingRound extends Round implements Observer {
 
                 // Are there any "common" special properties,
                 // i.e. properties that are available to everyone?
-                List<SpecialProperty> commonSP =
-                        gameManager.getCommonSpecialProperties();
+                List<SpecialProperty> commonSP = gameManager.getCommonSpecialProperties();
                 if (commonSP != null) {
                     SellBonusToken sbt;
                     loop:
@@ -586,7 +584,7 @@ public class OperatingRound extends Round implements Observer {
                                 && sp.isUsableDuringOR(step)) {
                             if (sp instanceof SpecialBaseTokenLay) {
                                 if (getStep() != GameDef.OrStep.LAY_TOKEN) {
-                                    possibleActions.add(new LayBaseToken(
+                                    possibleActions.add(new LayBaseToken(getRoot(),
                                             (SpecialBaseTokenLay) sp));
                                 }
                             } else if (!(sp instanceof SpecialTileLay)) {
@@ -605,7 +603,7 @@ public class OperatingRound extends Round implements Observer {
                                 && sp.isUsableDuringOR(step)) {
                             if (sp instanceof SpecialBaseTokenLay) {
                                 if (getStep() != GameDef.OrStep.LAY_TOKEN) {
-                                    possibleActions.add(new LayBaseToken(
+                                    possibleActions.add(new LayBaseToken(getRoot(),
                                             (SpecialBaseTokenLay) sp));
                                 }
                             } else {
@@ -618,7 +616,7 @@ public class OperatingRound extends Round implements Observer {
         }
 
         if (doneAllowed) {
-            possibleActions.add(new NullAction(NullAction.Mode.DONE));
+            possibleActions.add(new NullAction(getRoot(), NullAction.Mode.DONE));
         }
 
         for (PossibleAction pa : possibleActions.getList()) {
@@ -815,11 +813,7 @@ public class OperatingRound extends Round implements Observer {
                 if (!company.canRunTrains()) {
                     // No trains, then the revenue is zero.
                     log.debug("OR skips {}: Cannot run trains", step);
-
-                    executeSetRevenueAndDividend(
-                            new SetDividend(0, false, new int[]{SetDividend.NO_TRAIN})
-                    );
-
+                    executeSetRevenueAndDividend(new SetDividend(getRoot(), 0, false, new int[] { SetDividend.NO_TRAIN }));
                     // TODO: This probably does not handle share selling correctly
                     continue;
                 }
@@ -1775,7 +1769,7 @@ public class OperatingRound extends Round implements Observer {
             }
         }
         if (!remainingTileLaysPerColour.isEmpty()) {
-            currentNormalTileLays.add(new LayTile(remainingTileLaysPerColour));
+            currentNormalTileLays.add(new LayTile(getRoot(), remainingTileLaysPerColour));
         }
 
         // NOTE: in a later stage tile lays will be specified per hex or set of
@@ -2135,7 +2129,7 @@ public class OperatingRound extends Round implements Observer {
 
         /* For now, we allow one token of the currently operating company */
         if (operatingCompany.value().getNumberOfFreeBaseTokens() > 0) {
-            currentNormalTokenLays.add(new LayBaseToken((List<MapHex>) null));
+            currentNormalTokenLays.add(new LayBaseToken(getRoot(), (List<MapHex>) null));
         }
 
     }
@@ -2183,7 +2177,7 @@ public class OperatingRound extends Round implements Observer {
                     }
                     if (!canLay) continue;
                 }
-                currentSpecialTokenLays.add(new LayBaseToken(stl));
+                currentSpecialTokenLays.add(new LayBaseToken(getRoot(), stl));
             }
         }
     }
@@ -2323,7 +2317,7 @@ public class OperatingRound extends Round implements Observer {
     protected void setBonusTokenLays() {
 
         for (SpecialBonusTokenLay stl : getSpecialProperties(SpecialBonusTokenLay.class)) {
-            possibleActions.add(new LayBonusToken(stl, stl.getToken()));
+            possibleActions.add(new LayBonusToken(getRoot(), stl, stl.getToken()));
         }
     }
 
@@ -2735,7 +2729,7 @@ public class OperatingRound extends Round implements Observer {
                             SetDividend.PAYOUT,
                             SetDividend.WITHHOLD};
 
-            possibleActions.add(new SetDividend(
+            possibleActions.add(new SetDividend(getRoot(),
                     operatingCompany.value().getLastRevenue(), true,
                     allowedRevenueActions));
         }
@@ -2746,7 +2740,7 @@ public class OperatingRound extends Round implements Observer {
         // LayTile Actions
         for (Integer tc : mapManager.getPossibleTileCosts()) {
             if (tc <= operatingCompany.value().getCash())
-                possibleActions.add(new OperatingCost(
+                possibleActions.add(new OperatingCost(getRoot(),
                         OperatingCost.OCType.LAY_TILE, tc, false));
         }
 
@@ -2779,7 +2773,7 @@ public class OperatingRound extends Round implements Observer {
                     // sequence
                     // costsSet can
                     // be zero
-                    possibleActions.add(new OperatingCost(
+                    possibleActions.add(new OperatingCost(getRoot(),
                             OperatingCost.OCType.LAY_BASE_TOKEN, cost, false));
             }
         }

--- a/src/main/java/net/sf/rails/game/PublicCompany.java
+++ b/src/main/java/net/sf/rails/game/PublicCompany.java
@@ -131,8 +131,7 @@ public class PublicCompany extends RailsAbstractItem implements Company, RailsMo
     /**
      * Company treasury, holding cash
      */
-    protected final PurseMoneyModel treasury =
-            PurseMoneyModel.create(this, "treasury", false);
+    protected final PurseMoneyModel treasury = PurseMoneyModel.create(this, "treasury", false);
 
     /**
      * PresidentModel
@@ -421,7 +420,6 @@ public class PublicCompany extends RailsAbstractItem implements Company, RailsMo
      * element
      */
     public void configureFromXML(Tag tag) throws ConfigurationException {
-
         longName = tag.getAttributeAsString("longname", getId());
         infoText = "<html>" + longName;
 
@@ -451,16 +449,14 @@ public class PublicCompany extends RailsAbstractItem implements Company, RailsMo
 
         numberOfBaseTokens = tag.getAttributeAsInteger("tokens", 1);
 
-        certsAreInitiallyAvailable
-                = tag.getAttributeAsBoolean("available", certsAreInitiallyAvailable);
+        certsAreInitiallyAvailable = tag.getAttributeAsBoolean("available", certsAreInitiallyAvailable);
 
         canBeRestarted = tag.getAttributeAsBoolean("restartable", canBeRestarted);
 
         Tag shareUnitTag = tag.getChild("ShareUnit");
         if (shareUnitTag != null) {
             shareUnit.set(shareUnitTag.getAttributeAsInteger("percentage", DEFAULT_SHARE_UNIT));
-            shareUnitsForSharePrice
-                    = shareUnitTag.getAttributeAsInteger("sharePriceUnits", shareUnitsForSharePrice);
+            shareUnitsForSharePrice = shareUnitTag.getAttributeAsInteger("sharePriceUnits", shareUnitsForSharePrice);
         }
 
         Tag homeBaseTag = tag.getChild("Home");
@@ -518,9 +514,7 @@ public class PublicCompany extends RailsAbstractItem implements Company, RailsMo
             splitAlways = split.equalsIgnoreCase("always");
             splitAllowed = split.equalsIgnoreCase("allowed");
 
-            payoutMustExceedPriceToMove =
-                    payoutTag.getAttributeAsBoolean("mustExceedPriceToMove",
-                            false);
+            payoutMustExceedPriceToMove = payoutTag.getAttributeAsBoolean("mustExceedPriceToMove", false);
         }
 
         Tag ownSharesTag = tag.getChild("TreasuryCanHoldOwnShares");
@@ -528,34 +522,27 @@ public class PublicCompany extends RailsAbstractItem implements Company, RailsMo
             canHoldOwnShares = true;
             treasuryPaysOut = true;
 
-            maxPercOfOwnShares =
-                    ownSharesTag.getAttributeAsInteger("maxPerc",
-                            maxPercOfOwnShares);
+            maxPercOfOwnShares = ownSharesTag.getAttributeAsInteger("maxPerc", maxPercOfOwnShares);
         }
 
         Tag trainsTag = tag.getChild("Trains");
         if (trainsTag != null) {
             trainLimit = trainsTag.getAttributeAsIntegerList("limit");
-            mustOwnATrain =
-                    trainsTag.getAttributeAsBoolean("mandatory", mustOwnATrain);
+            mustOwnATrain = trainsTag.getAttributeAsBoolean("mandatory", mustOwnATrain);
         }
 
         Tag initialTrainTag = tag.getChild("InitialTrain");
         if (initialTrainTag != null) {
             initialTrainType = initialTrainTag.getAttributeAsString("type");
-            initialTrainCost = initialTrainTag.getAttributeAsInteger("cost",
-                    initialTrainCost);
-            initialTrainTradeable = initialTrainTag.getAttributeAsBoolean("tradeable",
-                    initialTrainTradeable);
+            initialTrainCost = initialTrainTag.getAttributeAsInteger("cost", initialTrainCost);
+            initialTrainTradeable = initialTrainTag.getAttributeAsBoolean("tradeable", initialTrainTradeable);
         }
 
         Tag firstTrainTag = tag.getChild("FirstTrainCloses");
         if (firstTrainTag != null) {
-            String typeName =
-                    firstTrainTag.getAttributeAsString("type", "Private");
+            String typeName = firstTrainTag.getAttributeAsString("type", "Private");
             if (typeName.equalsIgnoreCase("Private")) {
-                privateToCloseOnFirstTrainName =
-                        firstTrainTag.getAttributeAsString("name");
+                privateToCloseOnFirstTrainName = firstTrainTag.getAttributeAsString("name");
             } else {
                 throw new ConfigurationException(
                         "Only Privates can be closed on first train buy");
@@ -573,8 +560,7 @@ public class PublicCompany extends RailsAbstractItem implements Company, RailsMo
             } else if (capType.equalsIgnoreCase("whenBought")) {
                 setCapitalisation(CAPITALISE_WHEN_BOUGHT);
             } else {
-                throw new ConfigurationException(
-                        "Invalid capitalisation type: " + capType);
+                throw new ConfigurationException("Invalid capitalisation type: " + capType);
             }
         }
 
@@ -658,7 +644,6 @@ public class PublicCompany extends RailsAbstractItem implements Company, RailsMo
                     ("mustTradeTrainsAtFixedPrice", mustTradeTrainsAtFixedPrice);
             canClose = optionsTag.getAttributeAsBoolean("canClose", canClose);
         }
-
     }
 
 

--- a/src/main/java/net/sf/rails/game/RailsRoot.java
+++ b/src/main/java/net/sf/rails/game/RailsRoot.java
@@ -27,15 +27,6 @@ public class RailsRoot extends Root implements RailsItem {
 
     private static final Logger log = LoggerFactory.getLogger(RailsRoot.class);
 
-    // currently we assume that there is only one instance running
-    // thus it is possible to retrieve that version
-    // TODO: Replace this by a full support of concurrent usage
-    private static RailsRoot instance;
-
-    public static RailsRoot getInstance() {
-        return instance;
-    }
-
     // Base XML file
     private static final String GAME_XML_FILE = "Game.xml";
 
@@ -73,17 +64,16 @@ public class RailsRoot extends Root implements RailsItem {
     }
 
     public static RailsRoot create(GameData gameData) throws ConfigurationException {
-        Preconditions.checkState(instance == null, "Currently only a single instance of RailsRoot is allowed");
-        instance = new RailsRoot(gameData);
+        RailsRoot root = new RailsRoot(gameData);
         log.debug("RailsRoot: instance created");
-        instance.init();
+        root.init();
         log.debug("RailsRoot: instance initialized");
-        instance.initGameFromXML();
+        root.initGameFromXML();
         log.debug("RailsRoot: game configuration initialized");
-        instance.finishConfiguration();
+        root.finishConfiguration();
         log.debug("RailsRoot: game configuration finished");
 
-        return instance;
+        return root;
     }
 
 
@@ -251,7 +241,4 @@ public class RailsRoot extends Root implements RailsItem {
         return this;
     }
 
-    public static void clearInstance() {
-        instance = null;
-    }
 }

--- a/src/main/java/net/sf/rails/game/StartRound_1830.java
+++ b/src/main/java/net/sf/rails/game/StartRound_1830.java
@@ -165,7 +165,7 @@ public class StartRound_1830 extends StartRound {
         }
 
         if (passAllowed) {
-            possibleActions.add(new NullAction(NullAction.Mode.PASS));
+            possibleActions.add(new NullAction(getRoot(), NullAction.Mode.PASS));
         }
 
        return true;

--- a/src/main/java/net/sf/rails/game/StartRound_AuctionOnly.java
+++ b/src/main/java/net/sf/rails/game/StartRound_AuctionOnly.java
@@ -54,7 +54,7 @@ public abstract class StartRound_AuctionOnly extends StartRound {
                                 startPacket.getModulus(), true);
                 possibleActions.add(possibleAction);
             }
-            possibleActions.add(new NullAction(NullAction.Mode.PASS));
+            possibleActions.add(new NullAction(getRoot(), NullAction.Mode.PASS));
         } else if (currentSharePriceItem() != null) {
             // Item sold, but needs share price
             StartItem currentItem = currentSharePriceItem();
@@ -82,7 +82,7 @@ public abstract class StartRound_AuctionOnly extends StartRound {
                 }
             }
             if (atLeastOneBiddable == true) {
-                possibleActions.add(new NullAction(NullAction.Mode.PASS));
+                possibleActions.add(new NullAction(getRoot(), NullAction.Mode.PASS));
             }
         }
 

--- a/src/main/java/net/sf/rails/game/financial/NationalFormationRound.java
+++ b/src/main/java/net/sf/rails/game/financial/NationalFormationRound.java
@@ -164,7 +164,7 @@ public class NationalFormationRound extends StockRound {
 
         } else if (step == Step.MERGE) {
 
-            possibleActions.add(new FoldIntoNational(foldablePreNationals));
+            possibleActions.add(new FoldIntoNational(getRoot(), foldablePreNationals));
 
         } else if (step == Step.DISCARD_TRAINS) {
 

--- a/src/main/java/net/sf/rails/game/financial/StockRound.java
+++ b/src/main/java/net/sf/rails/game/financial/StockRound.java
@@ -177,10 +177,10 @@ public class StockRound extends Round {
 
         if (passAllowed) {
             if (hasActed.value()) {
-                possibleActions.add(new NullAction(NullAction.Mode.DONE));
+                possibleActions.add(new NullAction(getRoot(), NullAction.Mode.DONE));
             } else {
-                possibleActions.add(new NullAction(NullAction.Mode.PASS));
-                possibleActions.add(new NullAction(NullAction.Mode.AUTOPASS));
+                possibleActions.add(new NullAction(getRoot(), NullAction.Mode.PASS));
+                possibleActions.add(new NullAction(getRoot(), NullAction.Mode.AUTOPASS));
             }
         }
 

--- a/src/main/java/net/sf/rails/game/financial/TreasuryShareRound.java
+++ b/src/main/java/net/sf/rails/game/financial/TreasuryShareRound.java
@@ -80,7 +80,7 @@ public class TreasuryShareRound extends StockRound {
             // TODO Finish the round before it started...
         }
 
-        possibleActions.add(new NullAction(NullAction.Mode.DONE));
+        possibleActions.add(new NullAction(getRoot(), NullAction.Mode.DONE));
 
         for (PossibleAction pa : possibleActions.getList()) {
             log.debug(operatingCompany.getId() + " may: " + pa.toString());

--- a/src/main/java/net/sf/rails/game/special/SpecialRight.java
+++ b/src/main/java/net/sf/rails/game/special/SpecialRight.java
@@ -43,7 +43,6 @@ public class SpecialRight extends SpecialProperty implements NetworkGraphModifie
 
     @Override
     public void configureFromXML(Tag tag) throws ConfigurationException {
-
         super.configureFromXML(tag);
 
         Tag rightTag = tag.getChild("SpecialRight");
@@ -55,23 +54,25 @@ public class SpecialRight extends SpecialProperty implements NetworkGraphModifie
         if (!Util.hasValue(rightName))
             throw new ConfigurationException(
                     "SpecialRight: no Right name specified");
-        
+
         rightDefaultValue = rightValue = rightTag.getAttributeAsString("defaultValue", null);
 
         cost = rightTag.getAttributeAsInteger("cost", 0);
-        
+
         locationNames = rightTag.getAttributeAsString("location", null);
     }
+
+    public void setRoot(RailsRoot root) { }
 
     @Override
     public void finishConfiguration (RailsRoot root) throws ConfigurationException {
         super.finishConfiguration(root);
-        
+
         // add them to the call list of the RevenueManager
         root.getRevenueManager().addGraphModifier(this);
-        
+
         if (locationNames != null) {
-            locations = new ArrayList<MapHex>();
+            locations = new ArrayList<>();
             MapManager mmgr = root.getMapManager();
             MapHex hex;
             for (String hexName : locationNames.split(",")) {
@@ -83,18 +84,18 @@ public class SpecialRight extends SpecialProperty implements NetworkGraphModifie
             }
         }
     }
-    
+
     public boolean isExecutionable() {
         // FIXME: Check if this works correctly
         // IT is better to rewrite this check
         // see ExchangeForShare
         return ((PrivateCompany)originalCompany).getOwner() instanceof Player;
     }
- 
+
     public String getName() {
         return rightName;
     }
-    
+
     public String getDefaultValue() {
         return rightDefaultValue;
     }
@@ -127,14 +128,14 @@ public class SpecialRight extends SpecialProperty implements NetworkGraphModifie
         if (cost > 0) b.append(" for ").append(Bank.format(this, cost));
         return b.toString();
     }
-    
+
     @Override
     public String toMenu() {
         return LocalText.getText("BuyRight",
                 rightName,
                 Bank.format(this, cost));
     }
-    
+
     public String getInfo() {
         return toMenu();
     }
@@ -149,15 +150,15 @@ public class SpecialRight extends SpecialProperty implements NetworkGraphModifie
         // 1. check operating company if it has the right then it is excluded from the removal
         // TODO: Only use one right for all companies instead of one per company
         if (this.getOriginalCompany() != company || company.hasRight(this)) return;
-        
+
         SimpleGraph<NetworkVertex, NetworkEdge> graph = routeGraph.getGraph();
-        
+
         // 2. find vertices to hex and remove the station
         Set<NetworkVertex> verticesToRemove = NetworkVertex.getVerticesByHexes(graph.vertexSet(), locations);
         // 3 ... and remove them from the graph
         graph.removeAllVertices(verticesToRemove);
     }
 
- 
+
 
 }

--- a/src/main/java/net/sf/rails/game/specific/_1825/StartRound_1825.java
+++ b/src/main/java/net/sf/rails/game/specific/_1825/StartRound_1825.java
@@ -79,7 +79,7 @@ public class StartRound_1825 extends StartRound {
             }
             if (soldShares == playerManager.getPlayers().size()){
                 //Enable passing
-                possibleActions.add(new NullAction(NullAction.Mode.PASS));
+                possibleActions.add(new NullAction(getRoot(), NullAction.Mode.PASS));
             }
         }
         return true;

--- a/src/main/java/net/sf/rails/game/specific/_1835/ElsasModifier.java
+++ b/src/main/java/net/sf/rails/game/specific/_1835/ElsasModifier.java
@@ -22,13 +22,16 @@ import org.slf4j.LoggerFactory;
 
 public class ElsasModifier implements NetworkGraphModifier {
 
-    private static final Logger log =
-            LoggerFactory.getLogger(ElsasModifier.class);
+    private static final Logger log = LoggerFactory.getLogger(ElsasModifier.class);
+
+    private RailsRoot root;
+
+    public void setRoot(RailsRoot root) {
+        this.root = root;
+    }
 
     @Override
     public void modifyMapGraph(NetworkGraph mapGraph) {
-        
-        RailsRoot root = RailsRoot.getInstance();
         SimpleGraph<NetworkVertex, NetworkEdge> graph = mapGraph.getGraph();
 
         // Check if (one of the  elsasHex has zero value ...
@@ -43,7 +46,7 @@ public class ElsasModifier implements NetworkGraphModifier {
             log.debug("Elsas is inactive");
         }
     }
-    
+
     @Override
     public void modifyRouteGraph(NetworkGraph mapGraph, PublicCompany company) {
         // do nothing

--- a/src/main/java/net/sf/rails/game/specific/_1835/PrussianFormationRound.java
+++ b/src/main/java/net/sf/rails/game/specific/_1835/PrussianFormationRound.java
@@ -139,7 +139,7 @@ public class PrussianFormationRound extends StockRound {
 
         } else if (step == Step.MERGE) {
 
-            possibleActions.add(new FoldIntoPrussian(foldablePrePrussians));
+            possibleActions.add(new FoldIntoPrussian(getRoot(), foldablePrePrussians));
 
         } else if (step == Step.DISCARD_TRAINS) {
 

--- a/src/main/java/net/sf/rails/game/specific/_1835/StartRound_1835.java
+++ b/src/main/java/net/sf/rails/game/specific/_1835/StartRound_1835.java
@@ -154,7 +154,7 @@ public class StartRound_1835 extends StartRound {
         }
 
         /* Pass is always allowed */
-        possibleActions.add(new NullAction(NullAction.Mode.PASS));
+        possibleActions.add(new NullAction(getRoot(), NullAction.Mode.PASS));
 
         return true;
     }

--- a/src/main/java/net/sf/rails/game/specific/_1837/BzHTileModifier.java
+++ b/src/main/java/net/sf/rails/game/specific/_1837/BzHTileModifier.java
@@ -19,15 +19,18 @@ import org.jgrapht.graph.SimpleGraph;
 
 public class BzHTileModifier implements NetworkGraphModifier {
 
-    private static final Logger log =
-        LoggerFactory.getLogger(BzHTileModifier.class);
+    private static final Logger log = LoggerFactory.getLogger(BzHTileModifier.class);
     private List<MapHex> bzhMapHexes = new ArrayList<MapHex> ();
+
+    private RailsRoot root;
+
+    public void setRoot(RailsRoot root) {
+        this.root = root;
+    }
 
     @Override
     public void modifyMapGraph(NetworkGraph mapGraph) {
-
         SimpleGraph<NetworkVertex, NetworkEdge> graph = mapGraph.getGraph();
-        RailsRoot root = RailsRoot.getInstance();
 
         // 1. check Phase
         // this is a violation of the assumption that the track network only dependents on the map configuration

--- a/src/main/java/net/sf/rails/game/specific/_1837/CoalExchangeRound.java
+++ b/src/main/java/net/sf/rails/game/specific/_1837/CoalExchangeRound.java
@@ -67,7 +67,7 @@ public class CoalExchangeRound extends StockRound_1837 {
         private boolean setMinorMergeActions() {
 
             if (hasActed.value()) {
-                possibleActions.add(new NullAction(NullAction.Mode.DONE));
+                possibleActions.add(new NullAction(getRoot(), NullAction.Mode.DONE));
                 return true;
             }
 
@@ -95,7 +95,7 @@ public class CoalExchangeRound extends StockRound_1837 {
                 }
             }
             if (!minors.isEmpty()) {
-                possibleActions.add(new NullAction(NullAction.Mode.DONE));
+                possibleActions.add(new NullAction(getRoot(), NullAction.Mode.DONE));
                 return true;
             }
 
@@ -117,7 +117,7 @@ public class CoalExchangeRound extends StockRound_1837 {
                     }
                 }
                 if (!minors.isEmpty()) {
-                    possibleActions.add(new NullAction(NullAction.Mode.DONE));
+                    possibleActions.add(new NullAction(getRoot(), NullAction.Mode.DONE));
                     return true;
                 }
                 //Inner loop

--- a/src/main/java/net/sf/rails/game/specific/_1837/FinalCoalExchangeRound.java
+++ b/src/main/java/net/sf/rails/game/specific/_1837/FinalCoalExchangeRound.java
@@ -22,7 +22,7 @@ public class FinalCoalExchangeRound extends StockRound_1837 {
 
         raiseIfSoldOut = false;
     }
-    
+
     public static FinalCoalExchangeRound create(GameManager parent, String id){
         return new FinalCoalExchangeRound(parent, id);
     }
@@ -53,7 +53,7 @@ public class FinalCoalExchangeRound extends StockRound_1837 {
     private boolean setMinorMergeActions() {
 
         if (hasActed.value()) {
-            possibleActions.add(new NullAction(NullAction.Mode.DONE));
+            possibleActions.add(new NullAction(getRoot(), NullAction.Mode.DONE));
             return true;
         }
 
@@ -100,7 +100,7 @@ public class FinalCoalExchangeRound extends StockRound_1837 {
     public boolean done(NullAction action, String playerName, boolean hasAutopassed) {
 
         // TODO: Here no action is stored
-        
+
 
         for (PublicCompany comp : companyManager.getAllPublicCompanies()) {
             if ((comp.getType().getId().equals("Coal")) && (!comp.isClosed())) {

--- a/src/main/java/net/sf/rails/game/specific/_1837/ItalyTileModifier.java
+++ b/src/main/java/net/sf/rails/game/specific/_1837/ItalyTileModifier.java
@@ -19,15 +19,18 @@ import org.jgrapht.graph.SimpleGraph;
 
 public class ItalyTileModifier implements NetworkGraphModifier {
 
-    private static final Logger log =
-        LoggerFactory.getLogger(ItalyTileModifier.class);
+    private static final Logger log = LoggerFactory.getLogger(ItalyTileModifier.class);
 
+    private RailsRoot root;
+
+    public void setRoot(RailsRoot root) {
+        this.root = root;
+    }
 
     @Override
     public void modifyMapGraph(NetworkGraph mapGraph) {
 
         SimpleGraph<NetworkVertex, NetworkEdge> graph = mapGraph.getGraph();
-        RailsRoot root = RailsRoot.getInstance();
         List<MapHex> italyMapHexes = new ArrayList<MapHex> ();
         // 1. check Phase
         // this is a violation of the assumption that the track network only dependents on the map configuration

--- a/src/main/java/net/sf/rails/game/specific/_1837/OperatingRound_1837.java
+++ b/src/main/java/net/sf/rails/game/specific/_1837/OperatingRound_1837.java
@@ -50,8 +50,6 @@ public class OperatingRound_1837 extends OperatingRound {
     private final BooleanState needHungaryFormationCall = new BooleanState(this, "NeedHungaryFormationCall");
     private final BooleanState needKuKFormationCall = new BooleanState(this, "NeedKuKFormationCall");
 
-
-
     /**
      * Registry of percentage of nationals revenue to be denied per player
      * because of having produced revenue in the same OR.
@@ -372,11 +370,8 @@ public class OperatingRound_1837 extends OperatingRound {
                 " companies treasury."
                 ));
 
-
-
         // Move the token
         ((PublicCompany_1837) operatingCompany.value()).payout(amount, b);
-
     }
 
 
@@ -445,7 +440,7 @@ public class OperatingRound_1837 extends OperatingRound {
     @Override
     protected boolean gameSpecificTileLayAllowed(PublicCompany company,
             MapHex hex, int orientation) {
-        RailsRoot root = RailsRoot.getInstance();
+        RailsRoot root = gameManager.getRoot();
         List<MapHex> italyMapHexes = new ArrayList<MapHex> ();
         // 1. check Phase
 
@@ -491,7 +486,7 @@ public class OperatingRound_1837 extends OperatingRound {
                             SetDividend.PAYOUT,
                             SetDividend.WITHHOLD };
 
-            possibleActions.add(new SetDividend(
+            possibleActions.add(new SetDividend(getRoot(),
                     operatingCompany.value().getLastRevenue(), operatingCompany.value().getLastDirectIncome(), true,
                     allowedRevenueActions,0));
         }

--- a/src/main/java/net/sf/rails/game/specific/_1837/StartRound_1837_2ndEd.java
+++ b/src/main/java/net/sf/rails/game/specific/_1837/StartRound_1837_2ndEd.java
@@ -72,7 +72,7 @@ public class StartRound_1837_2ndEd extends StartRound {
                         (StartItem) currentAuctionItem.value(),
                         currentBuyPrice.value(), true));
             }
-            possibleActions.add(new NullAction(NullAction.Mode.PASS));
+            possibleActions.add(new NullAction(getRoot(), NullAction.Mode.PASS));
             break;
         case OPEN_STEP:
         case BID_STEP:
@@ -85,9 +85,9 @@ public class StartRound_1837_2ndEd extends StartRound {
                 possibleActions.add(possibleAction);
             }
             if (currentStep.value() == OPEN_STEP) {
-                possibleActions.add(new NullAction(NullAction.Mode.PASS).setLabel("DeclineToBid"));
+                possibleActions.add(new NullAction(getRoot(), NullAction.Mode.PASS).setLabel("DeclineToBid"));
             } else {
-                possibleActions.add(new NullAction(NullAction.Mode.PASS));
+                possibleActions.add(new NullAction(getRoot(), NullAction.Mode.PASS));
             }
             break;
         }

--- a/src/main/java/net/sf/rails/game/specific/_1837/StartRound_1837_Coal.java
+++ b/src/main/java/net/sf/rails/game/specific/_1837/StartRound_1837_Coal.java
@@ -179,7 +179,7 @@ public class StartRound_1837_Coal extends StartRound {
                     return true;
                 }
             }
-            possibleActions.add(new NullAction(NullAction.Mode.PASS));
+            possibleActions.add(new NullAction(getRoot(), NullAction.Mode.PASS));
 
         }
 

--- a/src/main/java/net/sf/rails/game/specific/_1837/StartRound_1837_Minors_Hungary.java
+++ b/src/main/java/net/sf/rails/game/specific/_1837/StartRound_1837_Minors_Hungary.java
@@ -20,8 +20,8 @@ public class StartRound_1837_Minors_Hungary extends StartRound {
         super(gameManager, id, false, true, true);
         this.setStartRoundName("Minor Hungary StartRound");
     }
- 
-    
+
+
     /* (non-Javadoc)
      * @see net.sf.rails.game.specific._1837.StartRound_1837_Coal#start()
      */
@@ -36,7 +36,7 @@ public class StartRound_1837_Minors_Hungary extends StartRound {
             }
         }
         numPasses.set(0);
-        
+
         // init current with priority player
         startPlayer = playerManager.setCurrentToPriorityPlayer();
 
@@ -55,8 +55,8 @@ public class StartRound_1837_Minors_Hungary extends StartRound {
         }
 
         }
-   
-    
+
+
     /* (non-Javadoc)
      * @see net.sf.rails.game.specific._1837.StartRound_1837_Coal#setPossibleActions()
      */
@@ -81,7 +81,7 @@ public class StartRound_1837_Minors_Hungary extends StartRound {
                 possibleActions.clear();
                 return true;
             }
-        
+
 
         /*
          * Repeat until we have found a player with enough money to buy some
@@ -99,18 +99,18 @@ public class StartRound_1837_Minors_Hungary extends StartRound {
                     /* Player does have the cash */
                     possibleActions.add(new BuyStartItem(item,
                             item.getBasePrice(), false));
-    
+
                 }
             }  /* Pass is always allowed */
-            possibleActions.add(new NullAction(NullAction.Mode.PASS));
-                        
+            possibleActions.add(new NullAction(getRoot(), NullAction.Mode.PASS));
+
         }
 
         return true;
     }
 
- 
-    
+
+
     /**
      * Process a player's pass.
      *
@@ -162,4 +162,4 @@ public class StartRound_1837_Minors_Hungary extends StartRound {
         return false;
     }
 }
-        
+

--- a/src/main/java/net/sf/rails/game/specific/_1837/StartRound_1837_Minors_KuK.java
+++ b/src/main/java/net/sf/rails/game/specific/_1837/StartRound_1837_Minors_KuK.java
@@ -17,7 +17,7 @@ import net.sf.rails.game.StartRound;
 public class StartRound_1837_Minors_KuK extends StartRound {
 
     public StartRound_1837_Minors_KuK(GameManager gameManager, String id) {
-      
+
         super(gameManager, id, false, true, true);
         this.setStartRoundName("Minor KuK StartRound");
     }
@@ -46,11 +46,11 @@ public class StartRound_1837_Minors_KuK extends StartRound {
             }
         if (!fillPossibleActions(buyableItems)) {
             /* we dont have a valid player action */
-            possibleActions.add(new NullAction(NullAction.Mode.PASS));
-        } else {          
-        
+            possibleActions.add(new NullAction(getRoot(), NullAction.Mode.PASS));
+        } else {
+
         /* Pass is always allowed, we have a valid player action */
-        possibleActions.add(new NullAction(NullAction.Mode.PASS));
+        possibleActions.add(new NullAction(getRoot(), NullAction.Mode.PASS));
         }
         return true;
     }
@@ -72,15 +72,15 @@ public class StartRound_1837_Minors_KuK extends StartRound {
                 }
             break;
         }
-        if (possibleActions.isEmpty()) { 
-            return false; 
-        }       
+        if (possibleActions.isEmpty()) {
+            return false;
+        }
         return true;
     }
-    
+
     @Override
     public void start() {
-        
+
 
         for (StartItem item : startPacket.getItems()) {
             // New: we only include items that have not yet been sold
@@ -90,7 +90,7 @@ public class StartRound_1837_Minors_KuK extends StartRound {
             }
         }
         numPasses.set(0);
-        
+
         // init current with priority player
         startPlayer = playerManager.setCurrentToPriorityPlayer();
 
@@ -110,7 +110,7 @@ public class StartRound_1837_Minors_KuK extends StartRound {
 
     }
 
-    
+
     /**
      * Process a player's pass.
      *
@@ -161,4 +161,4 @@ public class StartRound_1837_Minors_KuK extends StartRound {
         return false;
     }
 }
-        
+

--- a/src/main/java/net/sf/rails/game/specific/_1851/BirminghamTileModifier.java
+++ b/src/main/java/net/sf/rails/game/specific/_1851/BirminghamTileModifier.java
@@ -17,15 +17,19 @@ import org.jgrapht.graph.SimpleGraph;
 
 public class BirminghamTileModifier implements NetworkGraphModifier {
 
-    private static final Logger log =
-        LoggerFactory.getLogger(BirminghamTileModifier.class);
+    private static final Logger log = LoggerFactory.getLogger(BirminghamTileModifier.class);
+
+    private RailsRoot root;
+
+    public void setRoot(RailsRoot root) {
+        this.root = root;
+    }
 
     @Override
     public void modifyMapGraph(NetworkGraph mapGraph) {
 
         // TODO (Rails 2.0): Add root reference to modifiers
         SimpleGraph<NetworkVertex, NetworkEdge> graph = mapGraph.getGraph();
-        RailsRoot root = RailsRoot.getInstance();
 
         // 1. check Phase
         // this is a violation of the assumption that the track network only dependents on the map configuration
@@ -43,7 +47,6 @@ public class BirminghamTileModifier implements NetworkGraphModifier {
         // 3 ... and remove them from the graph
         graph.removeAllVertices(birmingVertices);
         log.debug("Birmingham inactive, index of phase = " + phaseIndex);
-
     }
 
     @Override

--- a/src/main/java/net/sf/rails/game/specific/_1856/CGRFormationRound.java
+++ b/src/main/java/net/sf/rails/game/specific/_1856/CGRFormationRound.java
@@ -206,7 +206,7 @@ public class CGRFormationRound extends SwitchableUIRound {
             guiHints.setActivePanel(GuiDef.Panel.STATUS);
         } else if (step.value() == Steps.STEP_EXCHANGE_TOKENS) {
             int numberToExchange = cgr.getNumberOfFreeBaseTokens();
-            ExchangeTokens action = new ExchangeTokens(tokensToExchangeFrom,
+            ExchangeTokens action = new ExchangeTokens(getRoot(), tokensToExchangeFrom,
                     numberToExchange, numberToExchange);
             action.setCompany(cgr);
             possibleActions.add(action);

--- a/src/main/java/net/sf/rails/game/specific/_1856/OperatingRound_1856.java
+++ b/src/main/java/net/sf/rails/game/specific/_1856/OperatingRound_1856.java
@@ -120,7 +120,7 @@ public class OperatingRound_1856 extends OperatingRound {
                     && !((PublicCompany_CGR) operatingCompany.value()).hadPermanentTrain()) {
                 DisplayBuffer.add(this, LocalText.getText("MustWithholdUntilPermanent",
                         PublicCompany_CGR.NAME));
-                possibleActions.add(new SetDividend(
+                possibleActions.add(new SetDividend(getRoot(),
                         operatingCompany.value().getLastRevenue(), true,
                         new int[]{SetDividend.WITHHOLD}));
             } else {
@@ -146,7 +146,7 @@ public class OperatingRound_1856 extends OperatingRound {
                     }
                 }
 
-                possibleActions.add(new SetDividend(
+                possibleActions.add(new SetDividend(getRoot(),
                         operatingCompany.value().getLastRevenue(), true,
                         allowedRevenueActions,
                         requiredCash));
@@ -292,7 +292,7 @@ public class OperatingRound_1856 extends OperatingRound {
             }
         }
         if (possibleDestinations.size() > 0) {
-            possibleActions.add(new ReachDestinations(possibleDestinations));
+            possibleActions.add(new ReachDestinations(getRoot(), possibleDestinations));
         }
     }
 

--- a/src/main/java/net/sf/rails/game/specific/_1880/OperatingRound_1880.java
+++ b/src/main/java/net/sf/rails/game/specific/_1880/OperatingRound_1880.java
@@ -124,7 +124,7 @@ public class OperatingRound_1880 extends OperatingRound {
                 allowedRevenueActions = new int[] { SetDividend.WITHHOLD };
             }
 
-            possibleActions.add(new SetDividend(
+            possibleActions.add(new SetDividend(getRoot(),
                     operatingCompany.value().getLastRevenue(), true,
                     allowedRevenueActions));
         }
@@ -989,12 +989,12 @@ public class OperatingRound_1880 extends OperatingRound {
 
         ForcedRocketExchange action = null;
         if (ownedCompaniesWithSpace.isEmpty() == false) {
-            action = new ForcedRocketExchange();
+            action = new ForcedRocketExchange(getRoot());
             for (PublicCompany_1880 company : ownedCompaniesWithSpace) {
                 action.addCompanyWithSpace(company);
             }
         } else if (ownedCompaniesFull.isEmpty() == false) {
-            action = new ForcedRocketExchange();
+            action = new ForcedRocketExchange(getRoot());
             for (PublicCompany_1880 company : ownedCompaniesFull) {
                 action.addCompanyWithNoSpace(company);
             }

--- a/src/main/java/net/sf/rails/game/specific/_1880/ShareSellingRound_1880.java
+++ b/src/main/java/net/sf/rails/game/specific/_1880/ShareSellingRound_1880.java
@@ -51,7 +51,7 @@ public class ShareSellingRound_1880 extends ShareSellingRound {
 
         setSellableShares();
 
-        possibleActions.add(new NullAction(NullAction.Mode.DONE));
+        possibleActions.add(new NullAction(getRoot(), NullAction.Mode.DONE));
 
         for (PossibleAction pa : possibleActions.getList()) {
             log.debug(currentPlayer.getId() + " may: " + pa.toString());

--- a/src/main/java/net/sf/rails/game/specific/_1880/StartRound_Sequential.java
+++ b/src/main/java/net/sf/rails/game/specific/_1880/StartRound_Sequential.java
@@ -1,5 +1,5 @@
 /**
- * 
+ *
  */
 package net.sf.rails.game.specific._1880;
 
@@ -20,9 +20,9 @@ import rails.game.action.*;
 
 /**
  * @author Martin
- * 
+ *
  * Rails 2.0: OK
- * 
+ *
  */
 public class StartRound_Sequential extends StartRound {
 
@@ -64,7 +64,7 @@ public class StartRound_Sequential extends StartRound {
             currentItem.set(firstUnsoldItem);
             currentItem.value().setStatus(StartItem.BIDDABLE);
             passedPlayers.clear();
-        }        
+        }
     }
 
     private void setNextBiddingPlayer() {
@@ -96,12 +96,12 @@ public class StartRound_Sequential extends StartRound {
                 possibleActions.add(new BidStartItem(currentItem.value(),
                         currentItem.value().getMinimumBid(), startPacket.getModulus(), true));
             }
-            possibleActions.add(new NullAction(NullAction.Mode.PASS));
+            possibleActions.add(new NullAction(getRoot(), NullAction.Mode.PASS));
         }
-        
+
         return true;
     }
-    
+
     @Override
     protected boolean bid(String playerName, BidStartItem bidItem) {
         Player player = playerManager.getPlayerByName(playerName);
@@ -114,7 +114,7 @@ public class StartRound_Sequential extends StartRound {
         if (currentItem.value().getBid(player) > 0) {
             player.unblockCash(currentItem.value().getBid(player));
         }
-             
+
         currentItem.value().setBid(bidAmount, player);
         player.blockCash(bidAmount);
 
@@ -122,8 +122,8 @@ public class StartRound_Sequential extends StartRound {
                 playerName,
                 Bank.format(this,bidAmount),
                 bidItem.getStartItem().getId(),
-                Bank.format(this,player.getFreeCash())));        
-        
+                Bank.format(this,player.getFreeCash())));
+
         if ((passedPlayers.size() == (getRoot().getPlayerManager().getNumberOfPlayers() - 1))
             && (currentItem.value().getBidder() != null)) {
         // One player has bid, everyone else has passed.
@@ -134,7 +134,7 @@ public class StartRound_Sequential extends StartRound {
         }
         return true;
     }
-    
+
     private boolean validateBid(String playerName, BidStartItem bidItem) {
         String errMsg = null;
 
@@ -150,7 +150,7 @@ public class StartRound_Sequential extends StartRound {
                 errMsg = LocalText.getText("WrongItem", playerName, playerManager.getCurrentPlayer().getId());
                 break;
             }
-            
+
             // Check item
             boolean validItem = false;
             for (StartItemAction activeItem : possibleActions.getType(StartItemAction.class)) {
@@ -159,7 +159,7 @@ public class StartRound_Sequential extends StartRound {
                     break;
                 }
             }
-            
+
             if (!validItem) {
                 errMsg = LocalText.getText("ActionNotAllowed", bidItem.toString());
                 break;
@@ -213,14 +213,14 @@ public class StartRound_Sequential extends StartRound {
         }
 
         ReportBuffer.add(this, LocalText.getText("PASSES", playerName));
-        
+
         if (currentItem.value().getBid(player) > 0) {
             player.unblockCash(currentItem.value().getBid(player));
         }
 
         currentItem.value().setPass(player);
         passedPlayers.add(player);
-        
+
         if (passedPlayers.size() == playerManager.getNumberOfPlayers()) {
         // All players have passed - reduce price or run an operating round
             ReportBuffer.add(this, LocalText.getText("ALL_PASSED"));
@@ -249,7 +249,7 @@ public class StartRound_Sequential extends StartRound {
             assignItem(currentItem.value().getBidder(), currentItem.value(), currentItem.value().getBid()); // Could re-assign starting player...
         } else {
         // There are other players yet to bid
-            setNextBiddingPlayer();     
+            setNextBiddingPlayer();
         }
         return true;
     }
@@ -274,7 +274,7 @@ public class StartRound_Sequential extends StartRound {
                 Bank.format(this, price) ));
         itemAssigned(player, item, price);
     }
-    
+
     protected void itemAssigned(Player player, StartItem item, int price) {
     }
 

--- a/src/main/java/net/sf/rails/game/specific/_1889/OperatingRound_1889.java
+++ b/src/main/java/net/sf/rails/game/specific/_1889/OperatingRound_1889.java
@@ -70,7 +70,7 @@ public class OperatingRound_1889 extends OperatingRound {
                     else {
                         possibleActions.clear();
                         possibleActions.add(layTile);
-                        possibleActions.add(new NullAction(NullAction.Mode.SKIP));
+                        possibleActions.add(new NullAction(getRoot(), NullAction.Mode.SKIP));
                         DisplayBuffer.add(this, LocalText.getText("1889PrivateBactive", privB.getOwner()));
 
                     }
@@ -87,7 +87,7 @@ public class OperatingRound_1889 extends OperatingRound {
             if (validateSpecialTileLay(layTile)) {
                 possibleActions.clear();
                 possibleActions.add(layTile);
-                possibleActions.add(new NullAction(NullAction.Mode.SKIP));
+                possibleActions.add(new NullAction(getRoot(), NullAction.Mode.SKIP));
                 DisplayBuffer.add(this, LocalText.getText("1889PrivateCactive", previousOwnerName));
             }
         }

--- a/src/main/java/net/sf/rails/game/specific/_18AL/AssignNamedTrains.java
+++ b/src/main/java/net/sf/rails/game/specific/_18AL/AssignNamedTrains.java
@@ -11,6 +11,7 @@ import com.google.common.base.Objects;
 import net.sf.rails.game.RailsRoot;
 import net.sf.rails.game.Train;
 import net.sf.rails.game.TrainManager;
+import net.sf.rails.util.GameLoader;
 import net.sf.rails.util.RailsObjects;
 import rails.game.action.PossibleAction;
 import rails.game.action.UseSpecialProperty;
@@ -148,16 +149,18 @@ public class AssignNamedTrains extends UseSpecialProperty {
 
         in.defaultReadObject();
 
-        TrainManager trainManager = RailsRoot.getInstance().getTrainManager();
+        RailsRoot root = ((GameLoader.RailsObjectInputStream) in).getRoot();
 
-        nameableTrains = new ArrayList<NameableTrain>();
+        TrainManager trainManager = root.getTrainManager();
+
+        nameableTrains = new ArrayList<>();
         if (trainIds != null) {
             for (String trainId : trainIds) {
                 nameableTrains.add((NameableTrain) trainManager.getTrainByUniqueId(trainId));
             }
         }
 
-        preTrainPerToken = new ArrayList<NameableTrain>(numberOfTrains);
+        preTrainPerToken = new ArrayList<>(numberOfTrains);
         if (preTrainds != null) {
             for (String trainId : preTrainds) {
                 if (trainId != null && trainId.length() > 0) {
@@ -169,7 +172,7 @@ public class AssignNamedTrains extends UseSpecialProperty {
             }
         }
 
-        postTrainPerToken = new ArrayList<NameableTrain>(numberOfTrains);
+        postTrainPerToken = new ArrayList<>(numberOfTrains);
         if (postTrainds != null) {
             for (String trainId : postTrainds) {
                 if (trainId != null && trainId.length() > 0) {

--- a/src/main/java/net/sf/rails/game/specific/_18EU/FinalMinorExchangeRound.java
+++ b/src/main/java/net/sf/rails/game/specific/_18EU/FinalMinorExchangeRound.java
@@ -31,7 +31,7 @@ public final class FinalMinorExchangeRound extends StockRound_18EU {
 
         raiseIfSoldOut = false;
     }
-    
+
     public static FinalMinorExchangeRound create(GameManager parent, String id){
         return new FinalMinorExchangeRound(parent, id);
     }
@@ -62,7 +62,7 @@ public final class FinalMinorExchangeRound extends StockRound_18EU {
     private boolean setMinorMergeActions() {
 
         if (hasActed.value()) {
-            possibleActions.add(new NullAction(NullAction.Mode.DONE));
+            possibleActions.add(new NullAction(getRoot(), NullAction.Mode.DONE));
             return true;
         }
 
@@ -111,7 +111,7 @@ public final class FinalMinorExchangeRound extends StockRound_18EU {
     public boolean done(NullAction action, String playerName, boolean hasAutopassed) {
 
         // TODO: Here no action is stored
-        
+
 
         for (PublicCompany comp : companyManager.getAllPublicCompanies()) {
             if (comp.getType().getId().equals("Minor")) {

--- a/src/main/java/net/sf/rails/game/specific/_18EU/StartRound_18EU.java
+++ b/src/main/java/net/sf/rails/game/specific/_18EU/StartRound_18EU.java
@@ -68,7 +68,7 @@ public class StartRound_18EU extends StartRound {
                 if (currentBuyPrice.value() <= currentPlayer.getFreeCash()) {
                     possibleActions.add(new BuyStartItem(currentAuctionItem.value(), currentBuyPrice.value(), true));
                 }
-                possibleActions.add(new NullAction(NullAction.Mode.PASS));
+                possibleActions.add(new NullAction(getRoot(), NullAction.Mode.PASS));
                 break;
             case OPEN_STEP:
             case BID_STEP:
@@ -79,9 +79,9 @@ public class StartRound_18EU extends StartRound {
                     possibleActions.add(possibleAction);
                 }
                 if (currentStep.value() == OPEN_STEP) {
-                    possibleActions.add(new NullAction(NullAction.Mode.PASS).setLabel("DeclineToBid"));
+                    possibleActions.add(new NullAction(getRoot(), NullAction.Mode.PASS).setLabel("DeclineToBid"));
                 } else {
-                    possibleActions.add(new NullAction(NullAction.Mode.PASS));
+                    possibleActions.add(new NullAction(getRoot(), NullAction.Mode.PASS));
                 }
                 break;
         }

--- a/src/main/java/net/sf/rails/game/specific/_18NL/F21Modifier.java
+++ b/src/main/java/net/sf/rails/game/specific/_18NL/F21Modifier.java
@@ -19,10 +19,14 @@ import org.jgrapht.graph.SimpleGraph;
 
 public class F21Modifier implements NetworkGraphModifier {
 
+    private RailsRoot root;
+
+    public void setRoot(RailsRoot root) {
+        this.root = root;
+    }
+
     @Override
     public void modifyMapGraph(NetworkGraph mapGraph) {
-        
-        RailsRoot root = RailsRoot.getInstance();
         SimpleGraph<NetworkVertex, NetworkEdge> graph = mapGraph.getGraph();
 
         // Check if F21 has zero value
@@ -33,7 +37,7 @@ public class F21Modifier implements NetworkGraphModifier {
             graph.removeAllVertices(vertices);
         }
     }
-    
+
     @Override
     public void modifyRouteGraph(NetworkGraph mapGraph, PublicCompany company) {
         // do nothing

--- a/src/main/java/net/sf/rails/game/state/Root.java
+++ b/src/main/java/net/sf/rails/game/state/Root.java
@@ -8,9 +8,9 @@ import com.google.common.collect.Lists;
 /**
  * Root is the top node of the context/item hierachy
  */
-public class Root extends Context{
-    
-   public final static String ID = ""; 
+public class Root extends Context {
+
+   public final static String ID = "";
    private final static String TEXT_ID = "root";
 
    private StateManager stateManager;
@@ -19,7 +19,7 @@ public class Root extends Context{
    // only used during creation
    private boolean delayItems = true;
    private final List<Item> delayedItems = Lists.newArrayList();
-    
+
    protected Root() {
        addItem(this);
    }
@@ -33,7 +33,7 @@ public class Root extends Context{
        root.init();
        return root;
    }
-   
+
    protected void init() {
        StateManager stateManager = StateManager.create(this, "states");
        this.stateManager = stateManager;
@@ -48,13 +48,13 @@ public class Root extends Context{
        }
        delayItems = false;
    }
-   
+
    public StateManager getStateManager() {
        return stateManager;
    }
 
    // Item methods
-   
+
    /**
     * @throws UnsupportedOperationsException
     * Not supported for Root
@@ -66,21 +66,21 @@ public class Root extends Context{
    public String getId() {
        return "";
    }
-   
+
    /**
     * @return this
     */
    public Context getContext() {
        return this;
    }
-   
+
    /**
     * @return this
     */
    public Root getRoot() {
        return this;
    }
-   
+
    public String getURI() {
        return "";
    }
@@ -88,11 +88,11 @@ public class Root extends Context{
    public String getFullURI() {
        return "";
    }
-   
+
    public String toText() {
        return TEXT_ID;
    }
-   
+
    // Context methods
    public Item locate(String uri) {
        // first try as fullURI
@@ -106,31 +106,31 @@ public class Root extends Context{
    Item locateFullURI(String uri) {
        return items.get(uri);
    }
-   
+
    void addItem(Item item) {
        // check if it has to be delayed
        if (delayItems) {
            delayedItems.add(item);
            return;
        }
-       
+
        // check if it already exists
-       checkArgument(!items.containsKey(item.getFullURI()), 
+       checkArgument(!items.containsKey(item.getFullURI()),
                "Root already contains item with identical fullURI = " + item.getFullURI());
-       
+
        // all preconditions ok => add
        items.put(item.getFullURI(), item);
    }
 
    void removeItem(Item item) {
        // check if it already exists
-       checkArgument(items.containsKey(item.getFullURI()), 
+       checkArgument(items.containsKey(item.getFullURI()),
                "Root does not contain item with that fullURI = " + item.getFullURI());
-       
+
        // all preconditions ok => remove
        items.remove(item.getFullURI());
    }
-   
+
    @Override
    public String toString() {
        return TEXT_ID;

--- a/src/main/java/net/sf/rails/ui/swing/AutoLoadPoller.java
+++ b/src/main/java/net/sf/rails/ui/swing/AutoLoadPoller.java
@@ -92,7 +92,7 @@ public class AutoLoadPoller extends Thread {
                         }
                         lastSavedFilename = currentFilename;
 
-                        final GameAction reload = new GameAction(GameAction.Mode.RELOAD);
+                        final GameAction reload = new GameAction(guiMgr.getRoot(), GameAction.Mode.RELOAD);
                         reload.setFilepath(saveDirectory+"/"+currentFilename);
 
                         // The GUI must be accessed on the event dispatch thread only.

--- a/src/main/java/net/sf/rails/ui/swing/GUIGlobals.java
+++ b/src/main/java/net/sf/rails/ui/swing/GUIGlobals.java
@@ -19,9 +19,8 @@ import org.slf4j.LoggerFactory;
  */
 
 public class GUIGlobals {
-    private static final Logger log = 
-            LoggerFactory.getLogger(GUIGlobals.class);
-    
+    private static final Logger log = LoggerFactory.getLogger(GUIGlobals.class);
+
     private static double scale;
     private static double fontsScale;
     private static RenderingHints renderingHints;
@@ -39,20 +38,20 @@ public class GUIGlobals {
     public static double getFontsScale() {
         return fontsScale;
     }
-    
+
     public static void setRenderingHints(Graphics2D g) {
         g.setRenderingHints(renderingHints);
     }
-    
+
     public static RenderingHints getRenderingHints() {
         return renderingHints;
     }
-    
+
     /**
      * Set the scale so that the MasterBoard fits on the screen. Default scale
      * should be 15 for screen resolutions with height 1000 or more. For less,
      * scale it down linearly.
-     * 
+     *
      */
     private static void initMapScale() {
         Dimension d = Toolkit.getDefaultToolkit().getScreenSize();
@@ -66,7 +65,7 @@ public class GUIGlobals {
     }
 
     public static void initFontsScale() {
-        String fontScaleString = Config.getGameSpecific("font.ui.scale");
+        String fontScaleString = Config.get("font.ui.scale");
         if (Util.hasValue(fontScaleString)) {
             try {
                 fontsScale = Double.parseDouble(fontScaleString);
@@ -78,7 +77,7 @@ public class GUIGlobals {
         }
         log.debug("Fonts-Scale set to " + fontsScale);
     }
-    
+
     public static void initRenderingHints() {
         renderingHints = new RenderingHints(null);
         renderingHints.put(RenderingHints.KEY_ALPHA_INTERPOLATION,
@@ -96,6 +95,6 @@ public class GUIGlobals {
         renderingHints.put(RenderingHints.KEY_TEXT_ANTIALIASING,
                 RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
     }
-    
-    
+
+
 }

--- a/src/main/java/net/sf/rails/ui/swing/GameUIManager.java
+++ b/src/main/java/net/sf/rails/ui/swing/GameUIManager.java
@@ -253,11 +253,11 @@ public class GameUIManager implements DialogOwner {
 
     private void initFontSettings() {
         // font settings, can be game specific
-        String fontType = Config.getGameSpecific("font.ui.name");
+        String fontType = Config.getGameSpecific(railsRoot.getGameName(), "font.ui.name");
         Font font = null;
         if (Util.hasValue(fontType)) {
             boolean boldStyle = true;
-            String fontStyle = Config.getGameSpecific("font.ui.style");
+            String fontStyle = Config.getGameSpecific(railsRoot.getGameName(), "font.ui.style");
             if (Util.hasValue(fontStyle)) {
                 if (fontStyle.equalsIgnoreCase("plain")) {
                     boldStyle = false;
@@ -336,7 +336,7 @@ public class GameUIManager implements DialogOwner {
         gameUIInit(false); // false indicates reload
 
         splashWindow.notifyOfStep(SplashWindow.STEP_INIT_LOADED_GAME);
-        processAction(new NullAction(NullAction.Mode.START_GAME));
+        processAction(new NullAction(getRoot(), NullAction.Mode.START_GAME));
         statusWindow.setGameActions();
     }
 
@@ -838,7 +838,7 @@ public class GameUIManager implements DialogOwner {
 
     protected void autoSave(String newPlayer) {
         lastSavedFilename = savePrefix + "_" + saveDateTimeFormat.format(new Date()) + "_" + newPlayer + "." + saveExtension;
-        GameAction saveAction = new GameAction(GameAction.Mode.SAVE);
+        GameAction saveAction = new GameAction(getRoot(), GameAction.Mode.SAVE);
         saveAction.setFilepath(saveDirectory + "/" + lastSavedFilename);
         log.debug("Autosaving to {}", lastSavedFilename);
         processOnServer(saveAction);
@@ -1041,7 +1041,7 @@ public class GameUIManager implements DialogOwner {
                  * so the player can select a directory, and change
                  * the prefix if so desired.
                  */
-                GameAction saveAction = new GameAction(GameAction.Mode.SAVE);
+                GameAction saveAction = new GameAction(getRoot(), GameAction.Mode.SAVE);
                 saveSuffix = localPlayerName;
                 saveGame(saveAction);
                 lastSavedFilename = saveAction.getFilepath();

--- a/src/main/java/net/sf/rails/ui/swing/ORPanel.java
+++ b/src/main/java/net/sf/rails/ui/swing/ORPanel.java
@@ -622,7 +622,8 @@ implements ActionListener, KeyListener, RevenueListener {
             f = revenue[i] = new Field(c.getLastRevenueModel());
             addField(f, revXOffset, revYOffset + i, 1, 1, 0, visible);
 
-            f = revenueSelect[i] = new Spinner(0, 0, 0, GameManager.getRevenueSpinnerIncrement());
+            f = revenueSelect[i] = new Spinner(0, 0, 0,
+                    orUIManager.getGameUIManager().getGameManager().getRevenueSpinnerIncrement());
             //align spinner size with field size
             //(so that changes to visibility don't affect panel sizing)
             f.setPreferredSize(revenue[i].getPreferredSize());
@@ -637,7 +638,8 @@ implements ActionListener, KeyListener, RevenueListener {
                 f = directIncomeRevenue[i] = new Field(c.getLastDirectIncomeModel());
                 addField(f, bonusRevXOffset, bonusRevYOffset + i, 1, 1, 0, visible);
 
-                f = directIncomeSelect[i] = new Spinner(0, 0, 0, GameManager.getRevenueSpinnerIncrement());
+                f = directIncomeSelect[i] = new Spinner(0, 0, 0,
+                        orUIManager.getGameUIManager().getGameManager().getRevenueSpinnerIncrement());
 
                 f.setPreferredSize(directIncomeRevenue[i].getPreferredSize());
                 addField(f, bonusRevXOffset, bonusRevYOffset + i, 1, 1, 0,  false);

--- a/src/main/java/net/sf/rails/ui/swing/ORUIManager.java
+++ b/src/main/java/net/sf/rails/ui/swing/ORUIManager.java
@@ -81,8 +81,7 @@ import com.google.common.collect.Sets;
 // Rails 2.0, Even better add a new mechanism that allows to use the standard mechanism for corrections
 public class ORUIManager implements DialogOwner {
 
-    private static final Logger log =
-            LoggerFactory.getLogger(ORUIManager.class);
+    private static final Logger log = LoggerFactory.getLogger(ORUIManager.class);
 
     protected GameUIManager gameUIManager;
     protected NetworkAdapter networkAdapter;
@@ -271,7 +270,7 @@ public class ORUIManager implements DialogOwner {
         }
 
         // scroll map to center over companies network
-        String autoScroll = Config.getGameSpecific("map.autoscroll");
+        String autoScroll = Config.getGameSpecific(gameUIManager.getRoot().getGameName(), "map.autoscroll");
         if (Util.hasValue(autoScroll) &&  autoScroll.equalsIgnoreCase("no")) {
             // do nothing
         } else {
@@ -671,7 +670,7 @@ public class ORUIManager implements DialogOwner {
             map.selectHex(null);
             setLocalStep(LocalSteps.SELECT_HEX);
         } else {
-            orWindow.process(new NullAction(NullAction.Mode.SKIP));
+            orWindow.process(new NullAction(gameUIManager.getRoot(), NullAction.Mode.SKIP));
         }
     }
 

--- a/src/main/java/net/sf/rails/ui/swing/ReportWindow.java
+++ b/src/main/java/net/sf/rails/ui/swing/ReportWindow.java
@@ -263,11 +263,11 @@ public class ReportWindow extends JFrame implements
     private void gotoIndex(int index) {
         int currentIndex = changeStack.getCurrentIndex();
         if (index > currentIndex) { // move forward
-            GameAction action = new GameAction(GameAction.Mode.REDO);
+            GameAction action = new GameAction(gameUIManager.getRoot(), GameAction.Mode.REDO);
             action.setmoveStackIndex(index);
             gameUIManager.processAction(action);
         } else if (index < currentIndex) { // move backward
-            GameAction action = new GameAction(GameAction.Mode.FORCED_UNDO);
+            GameAction action = new GameAction(gameUIManager.getRoot(), GameAction.Mode.FORCED_UNDO);
             action.setmoveStackIndex(index);
             gameUIManager.processAction(action);
         }

--- a/src/main/java/net/sf/rails/ui/swing/StatusWindow.java
+++ b/src/main/java/net/sf/rails/ui/swing/StatusWindow.java
@@ -147,7 +147,7 @@ public class StatusWindow extends JFrame implements ActionListener, KeyListener,
                 ActionEvent.ALT_MASK));
         actionMenuItem.addActionListener(this);
         actionMenuItem.setEnabled(true);
-        actionMenuItem.setPossibleAction(new GameAction(GameAction.Mode.SAVE));
+        actionMenuItem.setPossibleAction(new GameAction(gameUIManager.getRoot(), GameAction.Mode.SAVE));
         fileMenu.add(actionMenuItem);
 
         actionMenuItem = new ActionMenuItem(LocalText.getText("Reload"));
@@ -157,7 +157,7 @@ public class StatusWindow extends JFrame implements ActionListener, KeyListener,
                 ActionEvent.ALT_MASK));
         actionMenuItem.addActionListener(this);
         actionMenuItem.setEnabled(true);
-        actionMenuItem.setPossibleAction(new GameAction(GameAction.Mode.RELOAD));
+        actionMenuItem.setPossibleAction(new GameAction(gameUIManager.getRoot(), GameAction.Mode.RELOAD));
         fileMenu.add(actionMenuItem);
 
         menuItem = new JMenuItem(LocalText.getText("AutoSaveLoad"));

--- a/src/main/java/net/sf/rails/ui/swing/hexmap/HexMap.java
+++ b/src/main/java/net/sf/rails/ui/swing/hexmap/HexMap.java
@@ -634,9 +634,8 @@ public abstract class HexMap implements MouseListener, MouseMotionListener {
      * defines settings from the config files
      */
     private void initializeSettings() {
-
         // define zoomStep from config
-        String zoomStepSetting = Config.getGameSpecific("map.zoomstep");
+        String zoomStepSetting = Config.getGameSpecific(mapManager.getRoot().getGameName(), "map.zoomstep");
         if (Util.hasValue(zoomStepSetting)) {
             try {
                 int newZoomStep = Integer.parseInt(zoomStepSetting);

--- a/src/main/java/net/sf/rails/ui/swing/hexmap/HexMapImage.java
+++ b/src/main/java/net/sf/rails/ui/swing/hexmap/HexMapImage.java
@@ -25,19 +25,15 @@ public final class HexMapImage extends JSVGCanvas  {
     // TODO: Is this still compatible
     private static final long serialVersionUID = 1L;
 
-    private static final Logger log =
-            LoggerFactory.getLogger(HexMapImage.class);
+    private static final Logger log = LoggerFactory.getLogger(HexMapImage.class);
 
     private MapManager mapManager;
     private HexMap hexMap;
     private double zoomFactor = 1;  // defined dynamically if zoomStep changed
     private int zoomStep = 10; // default value, can be overwritten in config
     private boolean initialized = false;
-    private Dimension initialMapSize = null;
-    private int initialZoomStep = 0;
 
     public void init(MapManager mapManager,HexMap hexMap) {
-
        this.mapManager = mapManager;
        this.hexMap = hexMap;
 
@@ -52,7 +48,7 @@ public final class HexMapImage extends JSVGCanvas  {
      */
     private void initializeSettings() {
         // define zoomStep from config
-        String zoomStepSetting = Config.getGameSpecific("map.zoomstep");
+        String zoomStepSetting = Config.getGameSpecific(mapManager.getRoot().getGameName(), "map.zoomstep");
         if (Util.hasValue(zoomStepSetting)) {
             try {
                 int newZoomStep = Integer.parseInt(zoomStepSetting);
@@ -117,8 +113,6 @@ public final class HexMapImage extends JSVGCanvas  {
             setPreferredSize(currentMapSize);
             zoom(zoomStep);
         } else {
-            initialMapSize = currentMapSize;
-            initialZoomStep = zoomStep;
         }
     }
     public void zoom (boolean in) {

--- a/src/main/java/net/sf/rails/util/GameLoader.java
+++ b/src/main/java/net/sf/rails/util/GameLoader.java
@@ -271,7 +271,6 @@ public class GameLoader {
      * @return false if exception occurred
      */
     public boolean replayGame() {
-
         GameManager gameManager = railsRoot.getGameManager();
         log.debug("Starting to execute loaded actions");
         gameManager.setReloading(true);
@@ -385,16 +384,14 @@ public class GameLoader {
 //        }
     }
 
-    public boolean reloadGameFromFile(File file) {
-
+    public boolean reloadGameFromFile(RailsRoot root, File file) {
         try {
+            railsRoot = root;
             // 1st: loadGameData
             loadGameData(file);
 
-            railsRoot = RailsRoot.getInstance();
             // 2nd: convert game data (retrieve actions)
             convertGameData();
-
 
         } catch (Exception e) {
             log.debug("Exception during createFromFile in gameLoader ", e);
@@ -402,6 +399,5 @@ public class GameLoader {
             return false;
         }
         return true;
-
     }
 }

--- a/src/main/java/rails/game/action/BuyBonusToken.java
+++ b/src/main/java/rails/game/action/BuyBonusToken.java
@@ -19,9 +19,9 @@ public class BuyBonusToken extends PossibleORAction {
     // Initial attributes
     transient private PrivateCompany privateCompany;
     private String privateCompanyName;
-    transient private Owner seller = null;
+    transient private Owner seller;
     private String sellerName = null;
-    transient protected SellBonusToken specialProperty = null;
+    transient protected SellBonusToken specialProperty;
     protected int specialPropertyId;
 
     private String name;
@@ -35,7 +35,7 @@ public class BuyBonusToken extends PossibleORAction {
      *
      */
     public BuyBonusToken(SellBonusToken specialProperty) {
-
+        super(specialProperty.getRoot());
         this.specialProperty = specialProperty;
         this.specialPropertyId = specialProperty.getUniqueId();
         this.privateCompany = (PrivateCompany) specialProperty.getOriginalCompany();
@@ -92,10 +92,10 @@ public class BuyBonusToken extends PossibleORAction {
         // identity always true
         if (pa == this) return true;
         //  super checks both class identity and super class attributes
-        if (!super.equalsAs(pa, asOption)) return false; 
+        if (!super.equalsAs(pa, asOption)) return false;
 
         // check asOption attributes
-        BuyBonusToken action = (BuyBonusToken)pa; 
+        BuyBonusToken action = (BuyBonusToken)pa;
         return Objects.equal(this.privateCompany, action.privateCompany)
                 && Objects.equal(this.name, action.name)
                 && Objects.equal(this.price, action.price)
@@ -107,7 +107,7 @@ public class BuyBonusToken extends PossibleORAction {
 
     @Override
     public String toString() {
-        return super.toString() + 
+        return super.toString() +
                 RailsObjects.stringHelper(this)
                     .addToString("privateCompany", privateCompany)
                     .addToString("name", name)

--- a/src/main/java/rails/game/action/BuyPrivate.java
+++ b/src/main/java/rails/game/action/BuyPrivate.java
@@ -24,9 +24,8 @@ public class BuyPrivate extends PossibleORAction {
 
     public static final long serialVersionUID = 1L;
 
-    public BuyPrivate(PrivateCompany privateCompany, int minimumPrice,
-            int maximumPrice) {
-
+    public BuyPrivate(PrivateCompany privateCompany, int minimumPrice, int maximumPrice) {
+        super(privateCompany.getRoot());
         this.privateCompany = privateCompany;
         this.privateCompanyName = privateCompany.getId();
         this.minimumPrice = minimumPrice;
@@ -67,18 +66,18 @@ public class BuyPrivate extends PossibleORAction {
         // identity always true
         if (pa == this) return true;
         //  super checks both class identity and super class attributes
-        if (!super.equalsAs(pa, asOption)) return false; 
+        if (!super.equalsAs(pa, asOption)) return false;
 
         // check asOption attributes
-        BuyPrivate action = (BuyPrivate)pa; 
+        BuyPrivate action = (BuyPrivate)pa;
         boolean options =  Objects.equal(this.privateCompany, action.privateCompany)
                 && Objects.equal(this.minimumPrice, action.minimumPrice)
                 && Objects.equal(this.maximumPrice, action.maximumPrice)
         ;
-        
+
         // finish if asOptions check
         if (asOption) return options;
-        
+
         // check asAction attributes
         return options
                 && Objects.equal(this.price, action.price)
@@ -87,7 +86,7 @@ public class BuyPrivate extends PossibleORAction {
 
     @Override
     public String toString() {
-        return super.toString() + 
+        return super.toString() +
                 RailsObjects.stringHelper(this)
                     .addToString("privateCompany", privateCompany)
                     .addToString("minimumPrice", minimumPrice)

--- a/src/main/java/rails/game/action/DiscardTrain.java
+++ b/src/main/java/rails/game/action/DiscardTrain.java
@@ -13,6 +13,7 @@ import net.sf.rails.game.RailsRoot;
 import net.sf.rails.game.Train;
 import net.sf.rails.game.TrainManager;
 import net.sf.rails.game.TrainType;
+import net.sf.rails.util.GameLoader;
 import net.sf.rails.util.RailsObjects;
 
 /**
@@ -21,10 +22,12 @@ import net.sf.rails.util.RailsObjects;
 public class DiscardTrain extends PossibleORAction {
 
     // Server settings
-    transient private Set<Train> ownedTrains = null;
+    transient private Set<Train> ownedTrains;
     private String[] ownedTrainsUniqueIds;
 
-    /** True if discarding trains is mandatory */
+    /**
+     * True if discarding trains is mandatory
+     */
     private boolean forced = false;
 
     // Client settings
@@ -34,12 +37,11 @@ public class DiscardTrain extends PossibleORAction {
     public static final long serialVersionUID = 1L;
 
     public DiscardTrain(PublicCompany company, Set<Train> trains) {
-
-        super();
+        super(company.getRoot());
         this.ownedTrains = trains;
         this.ownedTrainsUniqueIds = new String[trains.size()];
         int i = 0;
-        for (Train train:trains) {
+        for ( Train train : trains ) {
             ownedTrainsUniqueIds[i++] = train.getId();
         }
         this.company = company;
@@ -58,7 +60,7 @@ public class DiscardTrain extends PossibleORAction {
 
     private Set<TrainType> getOwnedTrainTypes() {
         ImmutableSet.Builder<TrainType> types = ImmutableSet.builder();
-        for (Train train:ownedTrains) {
+        for ( Train train : ownedTrains ) {
             types.add(train.getType());
         }
         return types.build();
@@ -80,36 +82,35 @@ public class DiscardTrain extends PossibleORAction {
     @Override
     protected boolean equalsAs(PossibleAction pa, boolean asOption) {
         // identity always true
-        if (pa == this) return true;
+        if ( pa == this ) return true;
         //  super checks both class identity and super class attributes
-        if (!super.equalsAs(pa, asOption)) return false;
+        if ( !super.equalsAs(pa, asOption) ) return false;
 
         // check asOption attributes
-        DiscardTrain action = (DiscardTrain)pa;
+        DiscardTrain action = (DiscardTrain) pa;
         // TODO: only the types have to be identical, due Rails 1.x backward compatibility
         boolean options = Objects.equal(this.getOwnedTrainTypes(), action.getOwnedTrainTypes())
-                && Objects.equal(this.forced, action.forced)
-        ;
+                && Objects.equal(this.forced, action.forced);
 
         // finish if asOptions check
-        if (asOption) return options;
+        if ( asOption ) return options;
 
         // check asAction attributes
         // TODO: only the types have to be identical, due Rails 1.x backward compatibility
         return options
                 && Objects.equal(this.discardedTrain.getType(), action.discardedTrain.getType())
-        ;
+                ;
     }
 
     @Override
     public String toString() {
         return super.toString() +
                 RailsObjects.stringHelper(this)
-                    .addToString("ownedTrains", ownedTrains)
-                    .addToString("forced", forced)
-                    .addToStringOnlyActed("discardedTrain", discardedTrain)
-                    .toString()
-        ;
+                        .addToString("ownedTrains", ownedTrains)
+                        .addToString("forced", forced)
+                        .addToStringOnlyActed("discardedTrain", discardedTrain)
+                        .toString()
+                ;
     }
 
     /** Deserialize */
@@ -118,16 +119,17 @@ public class DiscardTrain extends PossibleORAction {
 
         in.defaultReadObject();
 
-        TrainManager trainManager = RailsRoot.getInstance().getTrainManager();
+        RailsRoot root = ((GameLoader.RailsObjectInputStream) in).getRoot();
+        TrainManager trainManager = root.getTrainManager();
 
-        if (discardedTrainUniqueId != null) {
+        if ( discardedTrainUniqueId != null ) {
             discardedTrain = trainManager.getTrainByUniqueId(discardedTrainUniqueId);
         }
 
-        if (ownedTrainsUniqueIds != null && ownedTrainsUniqueIds.length > 0) {
-            ownedTrains = new HashSet<Train>();
-            for (int i = 0; i < ownedTrainsUniqueIds.length; i++) {
-                ownedTrains.add(trainManager.getTrainByUniqueId(ownedTrainsUniqueIds[i]));
+        if ( ownedTrainsUniqueIds != null && ownedTrainsUniqueIds.length > 0 ) {
+            ownedTrains = new HashSet<>();
+            for ( String ownedTrainsUniqueId : ownedTrainsUniqueIds ) {
+                ownedTrains.add(trainManager.getTrainByUniqueId(ownedTrainsUniqueId));
             }
         }
     }

--- a/src/main/java/rails/game/action/ExchangeTokens.java
+++ b/src/main/java/rails/game/action/ExchangeTokens.java
@@ -5,6 +5,7 @@ import java.io.ObjectInputStream;
 import java.util.ArrayList;
 import java.util.List;
 
+import net.sf.rails.game.RailsRoot;
 import net.sf.rails.util.RailsObjects;
 
 import com.google.common.base.Objects;
@@ -14,11 +15,11 @@ import com.google.common.base.Objects;
  */
 
 // FIXME: This stores client settings (action results) in an external object (ExchangeableToken).
-// This is bad practice in Rails. This action is only used in 1856, maybe it should be a specific action there 
+// This is bad practice in Rails. This action is only used in 1856, maybe it should be a specific action there
 public class ExchangeTokens extends PossibleORAction {
 
     // Server settings
-    private List<ExchangeableToken> tokensToExchange = new ArrayList<ExchangeableToken>();
+    private List<ExchangeableToken> tokensToExchange;
     private int minNumberToExchange = 0;
     private int maxNumberToExchange = 0;
 
@@ -26,11 +27,11 @@ public class ExchangeTokens extends PossibleORAction {
 
     public static final long serialVersionUID = 1L;
 
-    public ExchangeTokens(List<ExchangeableToken> tokensToSelectFrom,
+    public ExchangeTokens(RailsRoot root, List<ExchangeableToken> tokensToSelectFrom,
             int minNumberToExchange,
             int maxNumberToExchange) {
 
-        super();
+        super(root);
         this.tokensToExchange = tokensToSelectFrom;
         this.minNumberToExchange = minNumberToExchange;
         this.maxNumberToExchange = maxNumberToExchange;
@@ -59,10 +60,10 @@ public class ExchangeTokens extends PossibleORAction {
         // identity always true
         if (pa == this) return true;
         //  super checks both class identity and super class attributes
-        if (!super.equalsAs(pa, asOption)) return false; 
+        if (!super.equalsAs(pa, asOption)) return false;
 
         // check asOption attributes
-        ExchangeTokens action = (ExchangeTokens)pa; 
+        ExchangeTokens action = (ExchangeTokens)pa;
         return Objects.equal(this.tokensToExchange, action.tokensToExchange)
                 && Objects.equal(this.minNumberToExchange, action.minNumberToExchange)
                 && Objects.equal(this.maxNumberToExchange, action.maxNumberToExchange)
@@ -72,7 +73,7 @@ public class ExchangeTokens extends PossibleORAction {
 
     @Override
     public String toString() {
-        return super.toString() + 
+        return super.toString() +
                 RailsObjects.stringHelper(this)
                     .addToString("tokensToExchange", tokensToExchange)
                     .addToString("minNumberToExchange", minNumberToExchange)

--- a/src/main/java/rails/game/action/FoldIntoNational.java
+++ b/src/main/java/rails/game/action/FoldIntoNational.java
@@ -1,5 +1,5 @@
 /**
- * 
+ *
  */
 package rails.game.action;
 
@@ -11,6 +11,7 @@ import java.util.List;
 
 import net.sf.rails.game.Company;
 import net.sf.rails.game.CompanyManager;
+import net.sf.rails.game.RailsRoot;
 import net.sf.rails.util.RailsObjects;
 import net.sf.rails.util.Util;
 
@@ -32,14 +33,14 @@ public class FoldIntoNational extends PossibleAction {
 
     public static final long serialVersionUID = 1L;
 
-    public FoldIntoNational(List<Company> companies) {
-        super(null); // not defined by an activity yet
+    public FoldIntoNational(RailsRoot root, List<Company> companies) {
+        super(root); // not defined by an activity yet
         this.foldableCompanies = companies;
         foldableCompanyNames = Util.joinNamesWithDelimiter(foldableCompanies, ",");
     }
 
     public FoldIntoNational(Company company) {
-        this (Arrays.asList(new Company[] {company}));
+        this (company.getRoot(), Arrays.asList(company));
     }
 
     public List<Company> getFoldedCompanies() {
@@ -72,21 +73,21 @@ public class FoldIntoNational extends PossibleAction {
         // identity always true
         if (pa == this) return true;
         //  super checks both class identity and super class attributes
-        if (!super.equalsAs(pa, asOption)) return false; 
+        if (!super.equalsAs(pa, asOption)) return false;
 
         // check asOption attributes
-        FoldIntoNational action = (FoldIntoNational)pa; 
-        boolean options = 
+        FoldIntoNational action = (FoldIntoNational)pa;
+        boolean options =
                 Objects.equal(this.foldableCompanies, action.foldableCompanies) ||
                     // additional conditions required as there is no sorting defined in old save files
                     this.foldableCompanies != null && action.foldableCompanies != null
                     && this.foldableCompanies.containsAll(action.foldableCompanies)
                     && action.foldableCompanies.containsAll(this.foldableCompanies)
         ;
-        
+
         // finish if asOptions check
         if (asOption) return options;
-        
+
         // check asAction attributes
         return options
                 && Objects.equal(this.foldedCompanies, action.foldedCompanies) ||
@@ -99,18 +100,18 @@ public class FoldIntoNational extends PossibleAction {
 
     @Override
     public String toString() {
-        return super.toString() + 
+        return super.toString() +
                 RailsObjects.stringHelper(this)
                     .addToString("foldableCompanies", foldableCompanies)
                     .addToStringOnlyActed("foldedCompanies", foldedCompanies)
                     .toString()
         ;
     }
-    
+
     /** Deserialize */
     private void readObject(ObjectInputStream in) throws IOException,
             ClassNotFoundException {
-        
+
         Company company;
 
         in.defaultReadObject();

--- a/src/main/java/rails/game/action/GameAction.java
+++ b/src/main/java/rails/game/action/GameAction.java
@@ -1,5 +1,6 @@
 package rails.game.action;
 
+import net.sf.rails.game.RailsRoot;
 import net.sf.rails.util.RailsObjects;
 
 import com.google.common.base.Objects;
@@ -11,7 +12,7 @@ import com.google.common.base.Objects;
  * Rails 2.0: Updated equals and toString methods
  */
 public class GameAction extends PossibleAction {
-    
+
     private static final long serialVersionUID = 1L;
 
     public static enum Mode { SAVE, LOAD, UNDO, FORCED_UNDO, REDO, EXPORT, RELOAD }
@@ -23,8 +24,8 @@ public class GameAction extends PossibleAction {
     protected String filePath = null; // Only applies to SAVE, LOAD and RELOAD
     protected int moveStackIndex = -1; // target moveStackIndex, only for FORCED_UNDO and REDO
 
-    public GameAction(Mode mode) {
-        super(null); // not defined by an activity yet
+    public GameAction(RailsRoot root, Mode mode) {
+        super(root); // not defined by an activity yet
         this.mode = mode;
     }
 
@@ -43,7 +44,7 @@ public class GameAction extends PossibleAction {
     public int getmoveStackIndex() {
         return moveStackIndex;
     }
-    
+
     public Mode getMode() {
         return mode;
     }
@@ -53,15 +54,15 @@ public class GameAction extends PossibleAction {
         // identity always true
         if (pa == this) return true;
         //  super checks both class identity and super class attributes
-        if (!super.equalsAs(pa, asOption)) return false; 
+        if (!super.equalsAs(pa, asOption)) return false;
 
         // check asOption attributes
-        GameAction action = (GameAction)pa; 
+        GameAction action = (GameAction)pa;
         boolean options = Objects.equal(this.mode, action.mode);
-        
+
         // finish if asOptions check
         if (asOption) return options;
-        
+
         // check asAction attributes
         return options
                 && Objects.equal(this.filePath, action.filePath)
@@ -70,7 +71,7 @@ public class GameAction extends PossibleAction {
     }
 
     public String toString() {
-        return super.toString() + 
+        return super.toString() +
                 RailsObjects.stringHelper(this)
                     .addToString("mode", mode)
                     .addToStringOnlyActed("filePath", filePath)

--- a/src/main/java/rails/game/action/LayBaseToken.java
+++ b/src/main/java/rails/game/action/LayBaseToken.java
@@ -9,6 +9,7 @@ import com.google.common.base.Objects;
 
 import net.sf.rails.game.MapHex;
 import net.sf.rails.game.MapManager;
+import net.sf.rails.game.RailsRoot;
 import net.sf.rails.game.Stop;
 import net.sf.rails.game.special.SpecialProperty;
 import net.sf.rails.game.special.SpecialBaseTokenLay;
@@ -39,16 +40,16 @@ public class LayBaseToken extends LayToken {
 
     public static final long serialVersionUID = 1L;
 
-    public LayBaseToken(int type) {
-        super();
+    public LayBaseToken(RailsRoot root, int type) {
+        super(root);
         this.type = type;
     }
-    
+
     /**
      * Lay a base token on one of a given list of locations.
      * <p>This constructor is only intended to be used for normal lays of non-home tokens
      * in the operating company LAY_TOKEN OR step.
-     * 
+     *
      * @param locations A list of valid locations (hexes) where the acting company can lay a base token.<br>
      * <i>Note:</i> Currently, the game engine cannot yet provide such a list, as all knowledge about routes
      * is contained in the user interface code. As a consequence, this constructor is only called
@@ -56,41 +57,39 @@ public class LayBaseToken extends LayToken {
      * In fact, the UI will now apply the restriction to valid locations only.
      * Over time, applying this restriction should be moved to the game engine.
      */
-    public LayBaseToken(List<MapHex> locations) {
-        super(locations);
+    public LayBaseToken(RailsRoot root, List<MapHex> locations) {
+        super(root, locations);
         type = LOCATION_SPECIFIC;
     }
 
     /** Lay a base token as allowed via a Special Property.
      * <p>The valid locations (hexes) of such a token should be defined inside the special property.
      * Typically, such locations do not need to be connected to the existing network of a company.
-     * 
+     *
      * @param specialProperty The special property that allows laying an extra or unconnected base token.
      */
-    public LayBaseToken(SpecialBaseTokenLay specialProperty) {
-        super(specialProperty);
+    public LayBaseToken(RailsRoot root, SpecialBaseTokenLay specialProperty) {
+        super(root, specialProperty);
         type = SPECIAL_PROPERTY;
     }
 
     /** Lay a base token on a given location.
      * <p> This constructor is specifically intended to allow the player to select a city for its <b>home</b> token
      * on a multi-city hex or tile (e.g. an OO tile, such as the Erie in 1830 or the THB in 1856).
-     * 
+     *
      * @param hex The hex on which a city must be selected to lay a home token on.
      */
-    public LayBaseToken (MapHex hex) {
-        super (hex);
+    public LayBaseToken (RailsRoot root, MapHex hex) {
+        super (root, hex);
         setChosenHex (hex);
         type = HOME_CITY;
     }
-    
-    
 
     @Deprecated
     public int getChosenStation() {
         return chosenStation;
     }
-    
+
     public Stop getChosenStop() {
         return chosenHex.getRelatedStop(chosenStation);
     }
@@ -102,13 +101,13 @@ public class LayBaseToken extends LayToken {
     public int getType() {
         return type;
     }
-    
-    
+
+
     @Override
     public SpecialBaseTokenLay getSpecialProperty() {
         return (SpecialBaseTokenLay)specialProperty;
     }
-    
+
     @Override
     public int getPotentialCost(MapHex hex) {
         if (hex == null) {
@@ -120,7 +119,7 @@ public class LayBaseToken extends LayToken {
                 return company.getBaseTokenLayCost(hex);
             }
         }
-              
+
     }
 
     @Override
@@ -133,15 +132,15 @@ public class LayBaseToken extends LayToken {
         // identity always true
         if (pa == this) return true;
         //  super checks both class identity and super class attributes
-        if (!super.equalsAs(pa, asOption)) return false; 
+        if (!super.equalsAs(pa, asOption)) return false;
 
         // check asOption attributes
-        LayBaseToken action = (LayBaseToken)pa; 
+        LayBaseToken action = (LayBaseToken)pa;
         boolean options = Objects.equal(this.type, action.type);
-        
+
         // finish if asOptions check
         if (asOption) return options;
-        
+
         // check asAction attributes
         return options
                 && Objects.equal(this.chosenStation, action.chosenStation)
@@ -152,10 +151,10 @@ public class LayBaseToken extends LayToken {
     public boolean isCorrection() {
         return (type == LayBaseToken.CORRECTION);
     }
-    
+
     @Override
     public String toString() {
-        return super.toString() + 
+        return super.toString() +
                 RailsObjects.stringHelper(this)
                     .addToString("type", type)
                     .addToStringOnlyActed("chosenStation", chosenStation)

--- a/src/main/java/rails/game/action/LayBonusToken.java
+++ b/src/main/java/rails/game/action/LayBonusToken.java
@@ -30,8 +30,8 @@ public class LayBonusToken extends LayToken {
 
     public static final long serialVersionUID = 1L;
 
-    public LayBonusToken(SpecialBonusTokenLay specialProperty, BonusToken token) {
-        super(specialProperty);
+    public LayBonusToken(RailsRoot root, SpecialBonusTokenLay specialProperty, BonusToken token) {
+        super(root, specialProperty);
         this.token = token;
         this.tokenId = token.getUniqueId();
     }

--- a/src/main/java/rails/game/action/LayTile.java
+++ b/src/main/java/rails/game/action/LayTile.java
@@ -13,6 +13,7 @@ import com.google.common.collect.Ordering;
 
 import net.sf.rails.game.MapHex;
 import net.sf.rails.game.MapManager;
+import net.sf.rails.game.RailsRoot;
 import net.sf.rails.game.Tile;
 import net.sf.rails.game.TileManager;
 import net.sf.rails.game.special.SpecialProperty;
@@ -79,17 +80,20 @@ public class LayTile extends PossibleORAction implements Comparable<LayTile> {
 
     public static final long serialVersionUID = 1L;
 
-    public LayTile(int type) {
+    public LayTile(RailsRoot root, int type) {
+        super(root);
         this.type = type;
     }
 
-    public LayTile(Map<String, Integer> tileColours) {
+    public LayTile(RailsRoot root, Map<String, Integer> tileColours) {
+        super(root);
         type = GENERIC;
         setTileColours (tileColours);
         // NOTE: tileColours is currently only used for Help purposes.
     }
 
     public LayTile(SpecialTileLay specialProperty) {
+        super(specialProperty.getRoot());
         type = SPECIAL_PROPERTY;
         this.locations = specialProperty.getLocations();
         if (locations != null) buildLocationNameString();

--- a/src/main/java/rails/game/action/LayToken.java
+++ b/src/main/java/rails/game/action/LayToken.java
@@ -6,6 +6,7 @@ import java.util.List;
 import com.google.common.base.Objects;
 
 import net.sf.rails.game.MapHex;
+import net.sf.rails.game.RailsRoot;
 import net.sf.rails.game.special.SpecialBaseTokenLay;
 import net.sf.rails.game.special.SpecialBonusTokenLay;
 import net.sf.rails.game.special.SpecialProperty;
@@ -40,35 +41,39 @@ public abstract class LayToken extends PossibleORAction {
     /**
      * Allow laying a base token on a given location.
      */
-    public LayToken(List<MapHex> locations) {
+    public LayToken(RailsRoot root, List<MapHex> locations) {
+        super(root);
         this.locations = locations;
         if (locations != null) {
-            this.locations = locations;
             buildLocationNameString();
         }
     }
 
-    public LayToken(SpecialBaseTokenLay specialProperty) {
+    public LayToken(RailsRoot root, SpecialBaseTokenLay specialProperty) {
+        super(root);
         this.locations = specialProperty.getLocations();
         if (locations != null) buildLocationNameString();
         this.specialProperty = specialProperty;
         this.specialPropertyId = specialProperty.getUniqueId();
     }
 
-    public LayToken(SpecialBonusTokenLay specialProperty) {
+    public LayToken(RailsRoot root, SpecialBonusTokenLay specialProperty) {
+        super(root);
         this.locations = specialProperty.getLocations();
         if (locations != null) buildLocationNameString();
         this.specialProperty = specialProperty;
         this.specialPropertyId = specialProperty.getUniqueId();
     }
 
-    public LayToken (MapHex hex) {
-    	this.locations = new ArrayList<MapHex>(1);
+    public LayToken (RailsRoot root, MapHex hex) {
+        super(root);
+    	this.locations = new ArrayList<>(1);
     	locations.add(hex);
         buildLocationNameString();
     }
 
-    public LayToken() {
+    public LayToken(RailsRoot root) {
+        super(root);
         this.locations = null;
     }
 

--- a/src/main/java/rails/game/action/MergeCompanies.java
+++ b/src/main/java/rails/game/action/MergeCompanies.java
@@ -11,6 +11,7 @@ import com.google.common.base.Objects;
 import net.sf.rails.game.CompanyManager;
 import net.sf.rails.game.MapHex;
 import net.sf.rails.game.PublicCompany;
+import net.sf.rails.game.RailsRoot;
 import net.sf.rails.util.RailsObjects;
 import rails.game.action.PossibleAction;
 
@@ -39,7 +40,7 @@ public class MergeCompanies extends PossibleAction {
      */
     public MergeCompanies(PublicCompany mergingCompany,
             List<PublicCompany> targetCompanies, boolean forced) {
-        super(null); // not defined by an activity yet
+        super(mergingCompany.getRoot()); // not defined by an activity yet
         this.mergingCompany = mergingCompany;
         this.mergingCompanyName = mergingCompany.getId();
         this.targetCompanies = targetCompanies;
@@ -70,7 +71,7 @@ public class MergeCompanies extends PossibleAction {
 
     /** Required for deserialization */
     public MergeCompanies() {
-        super(null); // not defined by an activity yet
+        super((RailsRoot) null); // not defined by an activity yet
     }
 
     public PublicCompany getMergingCompany() {

--- a/src/main/java/rails/game/action/NullAction.java
+++ b/src/main/java/rails/game/action/NullAction.java
@@ -3,29 +3,29 @@ package rails.game.action;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 
+import net.sf.rails.game.RailsRoot;
 import net.sf.rails.util.RailsObjects;
 
 import com.google.common.base.Objects;
 
 /**
- * 
+ *
  * Rails 2.0: Updated equals and toString methods
  */
 public class NullAction extends PossibleAction {
-    
-    private static final long serialVersionUID = 2L;
 
-    public static enum Mode { DONE, PASS, SKIP, AUTOPASS, START_GAME }
+    private static final long serialVersionUID = 2L;
+    public enum Mode { DONE, PASS, SKIP, AUTOPASS, START_GAME }
 
     // optional label that is returned on toString instead of the standard labels defined below
     private String optionalLabel = null;
 
     protected transient Mode mode_enum = null;
     // Remark: it would have been better to store the enum name, however due to backward compatibility not an option
-    protected int mode; 
+    protected int mode;
 
-    public NullAction(Mode mode) {
-        super(null); // not defined by an activity yet
+    public NullAction(RailsRoot root, Mode mode) {
+        super(root); // not defined by an activity yet
         this.mode_enum = mode;
         this.mode = mode.ordinal();
     }
@@ -33,7 +33,7 @@ public class NullAction extends PossibleAction {
     public Mode getMode() {
         return mode_enum;
     }
-    
+
     /** returns the NullAction itself */
     public NullAction setLabel(String label) {
         this.optionalLabel = label;
@@ -45,10 +45,10 @@ public class NullAction extends PossibleAction {
         // identity always true
         if (pa == this) return true;
         //  super checks both class identity and super class attributes
-        if (!super.equalsAs(pa, asOption)) return false; 
+        if (!super.equalsAs(pa, asOption)) return false;
 
         // check asOption attributes
-        NullAction action = (NullAction)pa; 
+        NullAction action = (NullAction)pa;
         return Objects.equal(this.mode, action.mode)
                 && Objects.equal(this.optionalLabel, action.optionalLabel)
         ;
@@ -57,7 +57,7 @@ public class NullAction extends PossibleAction {
 
    @Override
     public String toString() {
-       return super.toString() + 
+       return super.toString() +
                RailsObjects.stringHelper(this)
                    .addToString("mode", mode_enum)
                    .addToString("optionalLabel", optionalLabel)

--- a/src/main/java/rails/game/action/PossibleAction.java
+++ b/src/main/java/rails/game/action/PossibleAction.java
@@ -32,13 +32,14 @@ import com.google.common.base.Objects;
 
 public abstract class PossibleAction implements ChangeAction, Serializable {
 
+    transient protected RailsRoot root;
+
     protected String playerName;
     protected int playerIndex;
     transient protected Player player;
 
     protected boolean acted = false;
 
-    transient protected RailsRoot root;
     transient protected Activity activity;
 
     public static final long serialVersionUID = 3L;
@@ -47,13 +48,29 @@ public abstract class PossibleAction implements ChangeAction, Serializable {
 
     // TODO: Replace this by a constructor argument for the player
     public PossibleAction(Activity activity) {
-        root = RailsRoot.getInstance();
-        player = getRoot().getPlayerManager().getCurrentPlayer();
+        if ( activity == null ) {
+            return;
+        }
+        root = activity.getRoot();
+        setPlayer();
+        this.activity = activity;
+    }
+
+    public PossibleAction(RailsRoot root) {
+        if ( root == null ) {
+            log.debug("missing root", new Exception());
+            return;
+        }
+        this.root = root;
+        setPlayer();
+    }
+
+    private void setPlayer() {
+        player = root.getPlayerManager().getCurrentPlayer();
         if (player != null) {
             playerName = player.getId();
             playerIndex = player.getIndex();
         }
-        this.activity = activity;
     }
 
     public String getPlayerName() {
@@ -183,15 +200,14 @@ public abstract class PossibleAction implements ChangeAction, Serializable {
     private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
         in.defaultReadObject();
 
-        if (in instanceof RailsObjectInputStream) {
-            root = ((RailsObjectInputStream) in).getRoot();
-        }
+        root = ((RailsObjectInputStream) in).getRoot();
 
         if (playerName != null) {
-            player = getRoot().getPlayerManager().getPlayerByName(playerName);
+            player = root.getPlayerManager().getPlayerByName(playerName);
         } else {
-            player = getRoot().getPlayerManager().getPlayerByIndex(playerIndex);
+            player = root.getPlayerManager().getPlayerByIndex(playerIndex);
         }
     }
+
 
 }

--- a/src/main/java/rails/game/action/PossibleORAction.java
+++ b/src/main/java/rails/game/action/PossibleORAction.java
@@ -7,6 +7,7 @@ import com.google.common.base.Objects;
 
 import net.sf.rails.game.OperatingRound;
 import net.sf.rails.game.PublicCompany;
+import net.sf.rails.game.RailsRoot;
 import net.sf.rails.game.round.RoundFacade;
 import net.sf.rails.util.RailsObjects;
 import net.sf.rails.util.Util;
@@ -15,8 +16,8 @@ import net.sf.rails.util.Util;
  * PossibleAction is the superclass of all classes that describe an allowed user
  * action (such as laying a tile or dropping a token on a specific hex, buying a
  * train etc.).
- * 
- * Rails 2.0: Added updated equals and toString methods 
+ *
+ * Rails 2.0: Added updated equals and toString methods
  */
 public abstract class PossibleORAction extends PossibleAction {
 
@@ -29,8 +30,8 @@ public abstract class PossibleORAction extends PossibleAction {
     /**
      *
      */
-    public PossibleORAction() {
-        super(null); // not defined by an activity yet
+    public PossibleORAction(RailsRoot root) {
+        super(root); // not defined by an activity yet
         // TODO: The company field should be set from outside and not inside the action classes themselves
         RoundFacade round = getRoot().getGameManager().getCurrentRound();
         if (round instanceof OperatingRound) {
@@ -46,7 +47,7 @@ public abstract class PossibleORAction extends PossibleAction {
     public String getCompanyName() {
         return company.getId();
     }
-    
+
     /**
      * @return costs of executing the action, default for an ORAction is zero
      */
@@ -59,22 +60,22 @@ public abstract class PossibleORAction extends PossibleAction {
         this.company = company;
         this.companyName = company.getId();
     }
-    
-    
+
+
     @Override
     protected boolean equalsAs(PossibleAction pa, boolean asOption) {
         //  super checks both class identity and super class attributes
-        if (!super.equalsAs(pa, asOption)) return false; 
+        if (!super.equalsAs(pa, asOption)) return false;
 
         // check asOption attributes
-        PossibleORAction action = (PossibleORAction)pa; 
+        PossibleORAction action = (PossibleORAction)pa;
         return Objects.equal(this.company, action.company);
         // no asAction attributes to be checked
     }
-    
+
     @Override
     public String toString () {
-        return super.toString() + 
+        return super.toString() +
                 RailsObjects.stringHelper(this)
                 .addToString("company", company)
                 .toString()

--- a/src/main/java/rails/game/action/ReachDestinations.java
+++ b/src/main/java/rails/game/action/ReachDestinations.java
@@ -9,6 +9,7 @@ import com.google.common.base.Objects;
 
 import net.sf.rails.game.CompanyManager;
 import net.sf.rails.game.PublicCompany;
+import net.sf.rails.game.RailsRoot;
 import net.sf.rails.util.RailsObjects;
 import net.sf.rails.util.Util;
 
@@ -30,7 +31,8 @@ public class ReachDestinations extends PossibleORAction {
 
     public static final long serialVersionUID = 1L;
 
-    public ReachDestinations (List<PublicCompany> companies) {
+    public ReachDestinations (RailsRoot root, List<PublicCompany> companies) {
+        super(root);
         possibleCompanies = companies;
         StringBuilder b = new StringBuilder();
         for (PublicCompany company : companies) {
@@ -39,9 +41,6 @@ public class ReachDestinations extends PossibleORAction {
         }
         possibleCompanyNames = b.toString();
     }
-
-    /** Required for deserialization */
-    public ReachDestinations() {}
 
     public List<PublicCompany> getPossibleCompanies() {
         return possibleCompanies;

--- a/src/main/java/rails/game/action/RepayLoans.java
+++ b/src/main/java/rails/game/action/RepayLoans.java
@@ -27,7 +27,7 @@ public class RepayLoans extends PossibleAction {
 
     public RepayLoans(PublicCompany company, int minNumber, int maxNumber,
             int price) {
-        super(null); // not defined by an activity yet
+        super(company.getRoot()); // not defined by an activity yet
         this.company = company;
         this.companyName = company.getId();
         this.minNumber = minNumber;
@@ -77,20 +77,20 @@ public class RepayLoans extends PossibleAction {
         // identity always true
         if (pa == this) return true;
         //  super checks both class identity and super class attributes
-        if (!super.equalsAs(pa, asOption)) return false; 
+        if (!super.equalsAs(pa, asOption)) return false;
 
         // check asOption attributes
         RepayLoans action = (RepayLoans) pa;
-        boolean options = 
+        boolean options =
                 Objects.equal(this.company, action.company)
                 && Objects.equal(this.minNumber, action.minNumber)
                 && Objects.equal(this.maxNumber, action.maxNumber)
                 && Objects.equal(this.price, action.price)
         ;
-        
+
         // finish if asOptions check
         if (asOption) return options;
-        
+
         // check asAction attributes
         return options
                 && Objects.equal(this.numberRepaid, action.numberRepaid)
@@ -99,7 +99,7 @@ public class RepayLoans extends PossibleAction {
 
     @Override
     public String toString() {
-        return super.toString() + 
+        return super.toString() +
                 RailsObjects.stringHelper(this)
                     .addToString("company", company)
                     .addToString("minNumber", minNumber)

--- a/src/main/java/rails/game/action/RequestTurn.java
+++ b/src/main/java/rails/game/action/RequestTurn.java
@@ -19,7 +19,7 @@ public class RequestTurn extends PossibleAction {
     private String requestingPlayerName;
 
     public RequestTurn (Player player) {
-        super(null); // not defined by an activity yet
+        super(player.getRoot()); // not defined by an activity yet
         // Override player set by superclass
         if (player != null) {
             requestingPlayerName = player.getId();
@@ -29,8 +29,8 @@ public class RequestTurn extends PossibleAction {
     public String getRequestingPlayerName() {
         return requestingPlayerName;
     }
-    
-    
+
+
     @Override
     public String toMenu() {
         return LocalText.getText("RequestTurn", requestingPlayerName);
@@ -41,17 +41,17 @@ public class RequestTurn extends PossibleAction {
         // identity always true
         if (pa == this) return true;
         //  super checks both class identity and super class attributes
-        if (!super.equalsAs(pa, asOption)) return false; 
+        if (!super.equalsAs(pa, asOption)) return false;
 
         // check asOption attributes
-        RequestTurn action = (RequestTurn)pa; 
+        RequestTurn action = (RequestTurn)pa;
         return Objects.equal(this.requestingPlayerName, action.requestingPlayerName);
         // no asAction attributes to be checked
     }
-    
+
     @Override
     public String toString() {
-        return super.toString() + 
+        return super.toString() +
                 RailsObjects.stringHelper(this)
                     .addToString("requestingPlayerName", requestingPlayerName)
                     .toString()

--- a/src/main/java/rails/game/action/SellShares.java
+++ b/src/main/java/rails/game/action/SellShares.java
@@ -43,7 +43,7 @@ public class SellShares extends PossibleAction {
 
     public SellShares(PublicCompany company, int shareUnits, int number,
             int price, int presidentExchange) {
-        super(null); // not defined by an activity yet
+        super(company.getRoot()); // not defined by an activity yet
         this.company = company;
         this.shareUnits = shareUnits;
         this.price = price;
@@ -101,7 +101,7 @@ public class SellShares extends PossibleAction {
         // identity always true
         if (pa == this) return true;
         //  super checks both class identity and super class attributes
-        if (!super.equalsAs(pa, asOption)) return false; 
+        if (!super.equalsAs(pa, asOption)) return false;
 
         // check asOption attributes
         SellShares action = (SellShares) pa;
@@ -119,7 +119,7 @@ public class SellShares extends PossibleAction {
 
     @Override
     public String toString() {
-        return super.toString() + 
+        return super.toString() +
                 RailsObjects.stringHelper(this)
                     .addToString("company", company)
                     .addToString("shareUnit", shareUnit)

--- a/src/main/java/rails/game/action/SetDividend.java
+++ b/src/main/java/rails/game/action/SetDividend.java
@@ -5,6 +5,8 @@ import java.io.ObjectInputStream;
 import java.util.Arrays;
 
 import com.google.common.base.Objects;
+
+import net.sf.rails.game.RailsRoot;
 import net.sf.rails.util.RailsObjects;
 import net.sf.rails.util.Util;
 
@@ -76,19 +78,19 @@ public class SetDividend extends PossibleORAction implements Cloneable {
 
     public static final long serialVersionUID = 1L;
 
-    public SetDividend(int presetRevenue, boolean mayUserSetRevenue,
+    public SetDividend(RailsRoot root, int presetRevenue, boolean mayUserSetRevenue,
             int[] allowedAllocations) {
-        this (presetRevenue, 0, mayUserSetRevenue, allowedAllocations, 0);
+        this (root, presetRevenue, 0, mayUserSetRevenue, allowedAllocations, 0);
     }
 
-    public SetDividend(int presetRevenue, boolean mayUserSetRevenue,
+    public SetDividend(RailsRoot root, int presetRevenue, boolean mayUserSetRevenue,
                 int[] allowedAllocations, int requiredCash) {
-        this (presetRevenue, 0, mayUserSetRevenue, allowedAllocations, requiredCash);
+        this (root, presetRevenue, 0, mayUserSetRevenue, allowedAllocations, requiredCash);
     }
 
-    public SetDividend(int presetRevenue, int presetCompanyTreasuryRevenue, boolean mayUserSetRevenue,
+    public SetDividend(RailsRoot root, int presetRevenue, int presetCompanyTreasuryRevenue, boolean mayUserSetRevenue,
             int[] allowedAllocations, int requiredCash) {
-        super();
+        super(root);
         this.presetRevenue = presetRevenue;
         this.presetCompanyTreasuryRevenue = presetCompanyTreasuryRevenue;
         this.setMayUserSetRevenue(mayUserSetRevenue);
@@ -104,8 +106,7 @@ public class SetDividend extends PossibleORAction implements Cloneable {
 
     /** Clone an instance (used by clone) */
     protected SetDividend(SetDividend action) {
-
-        this(action.presetRevenue,
+        this(action.getRoot(), action.presetRevenue,
                 action.presetCompanyTreasuryRevenue,
                 action.getMayUserSetRevenue(),
                 action.getAllowedRevenueAllocations(),
@@ -170,7 +171,6 @@ public class SetDividend extends PossibleORAction implements Cloneable {
 
     @Override
     public Object clone() {
-
         SetDividend result = new SetDividend(this);
         result.setActualRevenue(actualRevenue);
         result.setActualCompanyTreasuryRevenue(actualCompanyTreasuryRevenue);

--- a/src/main/java/rails/game/action/StartCompany.java
+++ b/src/main/java/rails/game/action/StartCompany.java
@@ -19,9 +19,7 @@ public class StartCompany extends BuyCertificate {
 
     public StartCompany(PublicCompany company, int[] prices,
             int maximumNumber) {
-        super(company, company.getPresidentsShare().getShare(),
-                RailsRoot.getInstance().getBank().getIpo(),
-                0, maximumNumber);
+        super(company, company.getPresidentsShare().getShare(), null, 0, maximumNumber);
         this.startPrices = prices.clone();
     }
 
@@ -31,9 +29,7 @@ public class StartCompany extends BuyCertificate {
 
     public StartCompany(PublicCompany company, int price,
             int maximumNumber) {
-        super(company, company.getPresidentsShare().getShare(),
-                RailsRoot.getInstance().getBank().getIpo(),
-                0, maximumNumber);
+        super(company, company.getPresidentsShare().getShare(), null, 0, maximumNumber);
         this.price = price;
     }
 
@@ -60,27 +56,27 @@ public class StartCompany extends BuyCertificate {
         // identity always true
         if (pa == this) return true;
         //  super checks both class identity and super class attributes
-        if (!super.equalsAs(pa, asOption)) return false; 
+        if (!super.equalsAs(pa, asOption)) return false;
 
         // check asOption attributes
-        StartCompany action = (StartCompany)pa; 
-        boolean options = 
+        StartCompany action = (StartCompany)pa;
+        boolean options =
                 Arrays.equals(this.startPrices, action.startPrices)
         ;
-        
+
         // finish if asOptions check
         if (asOption) return options;
-        
+
         // check asAction attributes
         return options
                 && Objects.equal(this.price, action.price)
         // TODO: price has to be checked here, as this cannot be done in BuyCertificate
         ;
     }
-    
+
     @Override
     public String toString() {
-        return super.toString() + 
+        return super.toString() +
                 RailsObjects.stringHelper(this)
                     .addToString("startPrices", Arrays.toString(startPrices))
                     .toString()

--- a/src/main/java/rails/game/action/StartItemAction.java
+++ b/src/main/java/rails/game/action/StartItemAction.java
@@ -22,10 +22,10 @@ public abstract class StartItemAction extends PossibleAction {
     public static final long serialVersionUID = 1L;
 
     /**
-     * 
+     *
      */
     public StartItemAction(StartItem startItem) {
-        super(null); // not defined by an activity yet
+        super(startItem.getRoot()); // not defined by an activity yet
         this.startItem = startItem;
         this.startItemName = startItem.getId();
         this.itemIndex = startItem.getIndex();
@@ -45,30 +45,30 @@ public abstract class StartItemAction extends PossibleAction {
     public int getStatus() {
         return startItem.getStatus();
     }
-    
+
     @Override
     protected boolean equalsAs(PossibleAction pa, boolean asOption) {
         //  super checks both class identity and super class attributes
-        if (!super.equalsAs(pa, asOption)) return false; 
+        if (!super.equalsAs(pa, asOption)) return false;
 
         // check asOption attributes
-        StartItemAction action = (StartItemAction)pa; 
+        StartItemAction action = (StartItemAction)pa;
         return Objects.equal(this.startItem, action.startItem)
                 && Objects.equal(this.itemIndex, action.itemIndex)
         ;
         // no asAction attributes to be checked
     }
-    
+
     @Override
     public String toString() {
-        return super.toString() + 
+        return super.toString() +
                 RailsObjects.stringHelper(this)
                 .addToString("startItem", startItem)
                 .addToString("itemIndex", itemIndex)
                 .toString()
         ;
     }
-    
+
     private void readObject(ObjectInputStream in) throws IOException,
             ClassNotFoundException {
 

--- a/src/main/java/rails/game/action/TakeLoans.java
+++ b/src/main/java/rails/game/action/TakeLoans.java
@@ -27,7 +27,7 @@ public class TakeLoans extends PossibleORAction {
      */
     public TakeLoans(PublicCompany company, int maxNumber,
             int price) {
-
+        super(company.getRoot());
         this.company = company;
         this.companyName = company.getId();
         this.maxNumber = maxNumber;

--- a/src/main/java/rails/game/action/UseSpecialProperty.java
+++ b/src/main/java/rails/game/action/UseSpecialProperty.java
@@ -12,7 +12,7 @@ import net.sf.rails.util.RailsObjects;
 /**
  * This class can only be used to offer a Special Property to the UI that does
  * NOT need any return parameters. Example: the M&H/NYC swap in 1830.
- * 
+ *
  * Rails 2.0: Updated equals and toString methods
  */
 public class UseSpecialProperty extends PossibleORAction {
@@ -20,13 +20,13 @@ public class UseSpecialProperty extends PossibleORAction {
     /*--- Preconditions ---*/
 
     /** The special property that could be used */
-    transient protected SpecialProperty specialProperty = null;
+    transient protected SpecialProperty specialProperty;
     private int specialPropertyId;
 
     /*--- Postconditions ---*/
 
     public UseSpecialProperty(SpecialProperty specialProperty) {
-        super();
+        super(specialProperty.getRoot());
         this.specialProperty = specialProperty;
         if (specialProperty != null)
             this.specialPropertyId = specialProperty.getUniqueId();
@@ -50,17 +50,17 @@ public class UseSpecialProperty extends PossibleORAction {
         // identity always true
         if (pa == this) return true;
         //  super checks both class identity and super class attributes
-        if (!super.equalsAs(pa, asOption)) return false; 
+        if (!super.equalsAs(pa, asOption)) return false;
 
         // check asOption attributes
-        UseSpecialProperty action = (UseSpecialProperty)pa; 
+        UseSpecialProperty action = (UseSpecialProperty)pa;
         return Objects.equal(this.specialProperty, action.specialProperty);
         // no asAction attributes to be checked
     }
-    
+
     @Override
     public String toString() {
-        return super.toString() + 
+        return super.toString() +
                 RailsObjects.stringHelper(this)
                     .addToString("specialProperty", specialProperty)
                     .toString()

--- a/src/main/java/rails/game/correct/CashCorrectionAction.java
+++ b/src/main/java/rails/game/correct/CashCorrectionAction.java
@@ -6,6 +6,7 @@ import java.io.ObjectInputStream;
 
 import com.google.common.base.Objects;
 
+import net.sf.rails.game.RailsRoot;
 import rails.game.action.PossibleAction;
 import net.sf.rails.game.Player;
 import net.sf.rails.game.PublicCompany;
@@ -15,37 +16,38 @@ import net.sf.rails.util.Util;
 
 /**
  * Correction action that changes the cash position of a MoneyOwner.
- * 
+ *
  * Rails 2.0: updated equals and toString methods
  */
 public class CashCorrectionAction extends CorrectionAction {
 
     /** The Constant serialVersionUID. */
     public static final long serialVersionUID = 1L;
-    
+
     /* Preconditions */
-   
+
     /** cash holder */
-    transient private MoneyOwner correctCashHolder; 
+    transient private MoneyOwner correctCashHolder;
 
     /** converted to name */
-    private String cashHolderName; 
+    private String cashHolderName;
     private String cashHolderType;
 
     /** maximum Amount to deduct */
-    private int maximumNegative; 
-        
+    private int maximumNegative;
+
     /* Postconditions */
 
     /** selected cash amount */
-    private int correctAmount; 
-    
+    private int correctAmount;
+
    /**
     * Instantiates a new correct cash
-    * 
+    *
     * @param pl Player
     */
-   public CashCorrectionAction(Player pl) {
+   public CashCorrectionAction(RailsRoot root, Player pl) {
+       super(root);
        correctCashHolder = pl;
        cashHolderName = pl.getId();
        cashHolderType = "Player";
@@ -54,18 +56,19 @@ public class CashCorrectionAction extends CorrectionAction {
    }
    /**
     * Instantiates a new correct cash
-    * 
+    *
     * @param pc Public Company
     */
    public CashCorrectionAction(PublicCompany pc) {
+       super(pc.getRoot());
        correctCashHolder = pc;
        cashHolderName = pc.getId();
        cashHolderType = "PublicCompany";
        maximumNegative = pc.getCash();
        setCorrectionType(CorrectionType.CORRECT_CASH);
    }
-   
-   
+
+
    public MoneyOwner getCashHolder() {
        return correctCashHolder;
    }
@@ -85,31 +88,31 @@ public class CashCorrectionAction extends CorrectionAction {
    public void setAmount(int amount) {
        correctAmount = amount;
    }
-    
+
    @Override
    protected boolean equalsAs(PossibleAction pa, boolean asOption) {
        // identity always true
        if (pa == this) return true;
        //  super checks both class identity and super class attributes
-       if (!super.equalsAs(pa, asOption)) return false; 
+       if (!super.equalsAs(pa, asOption)) return false;
 
        // check asOption attributes
         CashCorrectionAction action = (CashCorrectionAction)pa;
         boolean options =  Objects.equal(this.correctCashHolder, action.correctCashHolder)
                 && Objects.equal(this.maximumNegative, action.maximumNegative)
         ;
-        
+
         // finish if asOptions check
         if (asOption) return options;
-        
+
         return options
                 && Objects.equal(this.correctAmount, action.correctAmount)
         ;
     }
-    
+
     @Override
     public String toString() {
-        return super.toString() + 
+        return super.toString() +
                 RailsObjects.stringHelper(this)
                     .addToString("correctCashHolder", correctCashHolder)
                     .addToString("maximumNegative", maximumNegative)
@@ -122,7 +125,7 @@ public class CashCorrectionAction extends CorrectionAction {
     private void readObject(ObjectInputStream in) throws IOException,
             ClassNotFoundException {
         in.defaultReadObject();
-        
+
         if (Util.hasValue(correctionName))
             correctionType = CorrectionType.valueOf(correctionName);
 

--- a/src/main/java/rails/game/correct/CashCorrectionManager.java
+++ b/src/main/java/rails/game/correct/CashCorrectionManager.java
@@ -14,23 +14,23 @@ import net.sf.rails.game.state.MoneyOwner;
 
 
 public class CashCorrectionManager extends CorrectionManager {
-    
+
     private CashCorrectionManager(GameManager parent) {
         super(parent, CorrectionType.CORRECT_CASH);
     }
-    
+
     public static CashCorrectionManager create(GameManager parent) {
         return new CashCorrectionManager(parent);
     }
-    
+
     @Override
     public List<CorrectionAction> createCorrections() {
         List<CorrectionAction> actions = super.createCorrections();
-        
+
         if (isActive()) {
             List<Player> players = getRoot().getPlayerManager().getPlayers();
             for(Player pl:players){
-                actions.add(new CashCorrectionAction(pl));
+                actions.add(new CashCorrectionAction(getRoot(), pl));
             }
 
             List<PublicCompany> publicCompanies = getParent().getAllPublicCompanies();
@@ -42,7 +42,7 @@ public class CashCorrectionManager extends CorrectionManager {
 
         return actions;
     }
-    
+
     @Override
     public boolean executeCorrection(CorrectionAction action){
         if (action instanceof CashCorrectionAction)
@@ -68,14 +68,14 @@ public class CashCorrectionManager extends CorrectionManager {
             }
             if ((amount + ch.getCash()) < 0) {
                 errMsg =
-                    LocalText.getText("NotEnoughMoney", 
+                    LocalText.getText("NotEnoughMoney",
                             ch.getId(),
                             Bank.format(this, ch.getCash()),
-                            Bank.format(this, -amount) 
+                            Bank.format(this, -amount)
                     );
                 break;
             }
-            break;   
+            break;
         }
 
         if (errMsg != null) {
@@ -84,9 +84,9 @@ public class CashCorrectionManager extends CorrectionManager {
                     errMsg));
             result = true;
         } else {
-            // no error occured 
-            
-            
+            // no error occured
+
+
 
             String msg;
             if (amount < 0) {
@@ -107,7 +107,7 @@ public class CashCorrectionManager extends CorrectionManager {
             getParent().addToNextPlayerMessages(msg, true);
             result = true;
         }
-    
+
        return result;
     }
 

--- a/src/main/java/rails/game/correct/ClosePrivate.java
+++ b/src/main/java/rails/game/correct/ClosePrivate.java
@@ -20,48 +20,48 @@ public class ClosePrivate extends PossibleAction {
     private static final long serialVersionUID = 2L;
 
     /* Preconditions */
-    
+
     /** private company to close */
     transient private PrivateCompany privateCompany;
-    
+
     /** converted to name */
-    private String privateCompanyName; 
+    private String privateCompanyName;
 
     /* Postconditions: None */
-    
+
     public ClosePrivate(PrivateCompany priv) {
-        super(null); // not defined by an activity yet
+        super(priv.getRoot()); // not defined by an activity yet
         privateCompany = priv;
         privateCompanyName = priv.getId();
     }
-    
+
     public PrivateCompany getPrivateCompany() {
         return privateCompany;
     }
     public String getPrivateCompanyName () {
         return privateCompanyName;
     }
-    
+
     public String getInfo(){
         return ("Close Private " + privateCompanyName);
     }
-    
+
     @Override
     protected boolean equalsAs(PossibleAction pa, boolean asOption) {
         // identity always true
         if (pa == this) return true;
         //  super checks both class identity and super class attributes
-        if (!super.equalsAs(pa, asOption)) return false; 
+        if (!super.equalsAs(pa, asOption)) return false;
 
         // check asOption attributes
-        ClosePrivate action = (ClosePrivate)pa; 
+        ClosePrivate action = (ClosePrivate)pa;
         return Objects.equal(this.privateCompany, action.privateCompany);
         // no asAction attributes to be checked
     }
 
     @Override
     public String toString() {
-        return super.toString() + 
+        return super.toString() +
                 RailsObjects.stringHelper(this)
                     .addToString("privateCompany", privateCompany)
                     .toString()

--- a/src/main/java/rails/game/correct/CorrectionAction.java
+++ b/src/main/java/rails/game/correct/CorrectionAction.java
@@ -1,53 +1,54 @@
 package rails.game.correct;
 
+import net.sf.rails.game.RailsRoot;
 import net.sf.rails.util.RailsObjects;
 
 import com.google.common.base.Objects;
 
 import rails.game.action.PossibleAction;
 /**
- * Base class for all actions that correct the state of the game. 
- * 
+ * Base class for all actions that correct the state of the game.
+ *
  * Rails 2.0: updated equals and toString methods
  */
 public abstract class CorrectionAction extends PossibleAction {
 
     transient protected CorrectionType correctionType;
     protected String correctionName;
-    
+
     public static final long serialVersionUID = 3L;
 
-    public CorrectionAction() {
-        super(null); // not defined by an activity yet
+    public CorrectionAction(RailsRoot root) {
+        super(root); // not defined by an activity yet
     }
 
     public CorrectionType getCorrectionType() {
         return correctionType;
     }
-    
+
     public String getCorrectionName() {
         return correctionName;
     }
-    
+
     public void setCorrectionType(CorrectionType correctionType) {
         this.correctionType = correctionType;
         this.correctionName = correctionType.name();
     }
-    
+
     @Override
     protected boolean equalsAs(PossibleAction pa, boolean asOption) {
         //  super checks both class identity and super class attributes
-        if (!super.equalsAs(pa, asOption)) return false; 
+        if (!super.equalsAs(pa, asOption)) return false;
 
         // check asOption attributes
         CorrectionAction action = (CorrectionAction)pa;
         return Objects.equal(this.correctionType, action.correctionType);
         // no action attributes to be checked
     }
-    
+
     @Override
     public String toString() {
-        return super.toString() + 
+        return super.toString() +
                 RailsObjects.stringHelper(this)
                     .addToString("correctionType", correctionType)
                 .toString()

--- a/src/main/java/rails/game/correct/CorrectionManager.java
+++ b/src/main/java/rails/game/correct/CorrectionManager.java
@@ -44,7 +44,7 @@ public abstract class CorrectionManager extends RailsAbstractItem {
     public List<CorrectionAction> createCorrections() {
 
         List<CorrectionAction> actions = new ArrayList<CorrectionAction>();
-        actions.add(new CorrectionModeAction(getCorrectionType(), isActive()));
+        actions.add(new CorrectionModeAction(getRoot(), getCorrectionType(), isActive()));
 
         return actions;
     }

--- a/src/main/java/rails/game/correct/CorrectionModeAction.java
+++ b/src/main/java/rails/game/correct/CorrectionModeAction.java
@@ -6,6 +6,7 @@ import java.io.ObjectInputStream;
 
 import com.google.common.base.Objects;
 
+import net.sf.rails.game.RailsRoot;
 import rails.game.action.PossibleAction;
 import net.sf.rails.common.LocalText;
 import net.sf.rails.util.*;
@@ -18,31 +19,32 @@ import net.sf.rails.util.*;
  */
 
 public class CorrectionModeAction extends CorrectionAction {
-    
+
     public static final long serialVersionUID = 1L;
 
     // pre-conditions:  state
     protected boolean active;
-    
+
     // post-conditions: none (except isActed!)
-    
-    /** 
+
+    /**
      * Initializes with all possible correction types
      */
-    public CorrectionModeAction(CorrectionType correction, boolean active) {
+    public CorrectionModeAction(RailsRoot root, CorrectionType correction, boolean active) {
+        super(root);
         this.correctionType = correction;
         correctionName = correction.name();
         this.active = active;
     }
-    
+
     public boolean isActive() {
         return active;
     }
-    
+
     public String getInfo(){
         return (LocalText.getText(correctionName));
     }
-    
+
     @Override
     protected boolean equalsAs(PossibleAction pa, boolean asOption) {
         // FIXME: Always allow the actions of the according type as Option
@@ -50,22 +52,22 @@ public class CorrectionModeAction extends CorrectionAction {
                 this.correctionType) {
             return true;
         }
-        
+
         // identity always true
         if (pa == this) return true;
         //  super checks both class identity and super class attributes
-        if (!super.equalsAs(pa, asOption)) return false; 
+        if (!super.equalsAs(pa, asOption)) return false;
 
         // check asOption attributes
         CorrectionModeAction action = (CorrectionModeAction)pa;
-        
+
         return Objects.equal(this.active, action.active);
         // no action attributes to be checked
     }
 
     @Override
     public String toString() {
-        return super.toString() + 
+        return super.toString() +
                 RailsObjects.stringHelper(this)
                     .addToString("active", active)
                 .toString()
@@ -80,22 +82,22 @@ public class CorrectionModeAction extends CorrectionAction {
                 correctionType = CorrectionType.valueOf(correctionName);
     }
 
-    
+
 //   a version with enumsets:
 //    // pre-conditions
 //    transient protected EnumSet<CorrectionType> possibleCorrections;
-//    
+//
 //    // post-conditions
 //    transient protected CorrectionType selectedCorrection;
-//    
-//    /** 
+//
+//    /**
 //     * Initializes with all possible correction types
 //     */
 //    public RequestCorrectionAction() {
 //        possibleCorrections = EnumSet.allOf(CorrectionType.class);
 //    }
 //
-//    /** 
+//    /**
 //     * Initializes with a specific set of correction types
 //     */
 //    public RequestCorrectionAction(EnumSet<CorrectionType> possibleCorrections) {
@@ -105,14 +107,14 @@ public class CorrectionModeAction extends CorrectionAction {
 //    public EnumSet<CorrectionType> getPossibleCorrections() {
 //        return possibleCorrections;
 //    }
-//    
+//
 //    public CorrectionType getSelectedCorrection() {
 //        return selectedCorrection;
 //    }
-//    
+//
 //    public void setSelectedCorrection(CorrectionType selectedCorrection) {
 //        this.selectedCorrection = selectedCorrection;
 //    }
-    
+
 
 }

--- a/src/main/java/rails/game/correct/MapCorrectionAction.java
+++ b/src/main/java/rails/game/correct/MapCorrectionAction.java
@@ -6,6 +6,7 @@ import java.util.*;
 
 import com.google.common.base.Objects;
 
+import net.sf.rails.game.RailsRoot;
 import rails.game.action.PossibleAction;
 import rails.game.correct.MapCorrectionManager.*;
 import net.sf.rails.game.BaseToken;
@@ -19,7 +20,7 @@ import net.sf.rails.util.Util;
 
 /**
  * Correction action for tile and token lays
- * 
+ *
  * Rails 2.0: updated equals and toString methods
  *
  * Deprecated since version 2.0
@@ -37,22 +38,22 @@ public class MapCorrectionAction extends CorrectionAction {
 
     transient private ActionStep nextStep = null;
     private String nextStepName;
-    
+
     /* Conditions */
-    
+
     /** Location: where to lay the tile */
     transient private MapHex location = null;
     private String locationCoordinates;
-    
+
     /** Tiles: which tile(s) to lay */
     transient private List<Tile> tiles = null;
     private String[] sTileIds;
     // FIXME: Rewrite this with Rails1.x version flag
     private int[] tileIds;
-    
+
     /** Orientation: how to lay the tile */
     private int orientation;
-    
+
     /** RelayBaseTokens: how to relay the base tokens */
     transient private List<BaseToken> tokensToRelay;
     //private String[]tokensToRelayOwner;
@@ -60,48 +61,49 @@ public class MapCorrectionAction extends CorrectionAction {
     //private int[] stationForRelayId;
     transient private Collection<Station> possibleStations;
     //private int[] possibleStationsId;
-                
+
     /**
      * Instantiates a new map tile correction action.
      * start with select hex
      */
-    public MapCorrectionAction() {
+    public MapCorrectionAction(RailsRoot root) {
+        super(root);
         setStep(ActionStep.SELECT_HEX);
         setNextStep(null);
         setCorrectionType(CorrectionType.CORRECT_MAP);
     }
-    
+
     public MapHex getLocation() {
         return location;
     }
-    
+
     private void setLocation(MapHex location) {
         this.location = location;
-        locationCoordinates = location.getId(); 
+        locationCoordinates = location.getId();
     }
-    
+
     public List<Tile> getTiles() {
         return tiles;
     }
-    
+
     public Tile getChosenTile() {
         if (nextStep.ordinal() > ActionStep.SELECT_TILE.ordinal())
             return tiles.get(0);
         else
             return null;
     }
-    
+
     void setTiles(List<Tile> tiles) {
         this.tiles = tiles;
         this.sTileIds = new String[tiles.size()];
         for (int i = 0; i < tiles.size(); i++)
             sTileIds[i] = tiles.get(i).getId();
     }
-    
+
     public List<Station> getStationsForRelay() {
         return stationsForRelay;
     }
-    
+
     private void setStationsForRelay(List<Station> stations) {
         this.stationsForRelay = stations;
     }
@@ -109,23 +111,23 @@ public class MapCorrectionAction extends CorrectionAction {
     public List<BaseToken> getTokensToRelay() {
         return tokensToRelay;
     }
-    
+
     void setTokensToRelay(List<BaseToken> tokens) {
         this.tokensToRelay = tokens;
     }
-    
+
     public Collection<Station> getPossibleStations() {
         return possibleStations;
     }
-    
+
     void setPossibleStations(Collection<Station> possibleStations) {
         this.possibleStations = possibleStations;
     }
-    
+
     public int getOrientation(){
         return orientation;
     }
-    
+
     private void setOrientation(int orientation) {
         this.orientation = orientation;
     }
@@ -133,7 +135,7 @@ public class MapCorrectionAction extends CorrectionAction {
     public ActionStep getNextStep() {
         return nextStep;
     }
-    
+
     void setNextStep(ActionStep step) {
         this.nextStep = step;
         if (step == null)
@@ -141,21 +143,21 @@ public class MapCorrectionAction extends CorrectionAction {
         else
             nextStepName = step.name();
     }
-    
+
     public ActionStep getStep() {
         return step;
     }
-    
+
     private void setStep(ActionStep step) {
         this.step = step;
         stepName = step.name();
     }
-    
+
     public void selectHex(MapHex chosenHex) {
         setLocation(chosenHex);
         setNextStep(ActionStep.SELECT_TILE);
     }
-    
+
     public void selectTile(Tile chosenTile) {
         List<Tile> tiles = new ArrayList<Tile>();
         tiles.add(chosenTile);
@@ -166,21 +168,21 @@ public class MapCorrectionAction extends CorrectionAction {
     public void selectConfirmed() {
         setNextStep(ActionStep.RELAY_BASETOKENS);
     }
-    
+
     public void selectOrientation(int orientation) {
         setOrientation(orientation);
         setNextStep(ActionStep.RELAY_BASETOKENS);
     }
-    
+
     public void selectRelayBaseTokens(List<Station> chosenStations) {
         setStationsForRelay(chosenStations);
         setNextStep(ActionStep.FINISHED);
     }
-    
+
     public void selectCancel() {
         setNextStep(ActionStep.CANCELLED);
     }
-    
+
     public ActionStep moveToNextStep() {
         setStep(nextStep);
         setNextStep(null);
@@ -188,19 +190,19 @@ public class MapCorrectionAction extends CorrectionAction {
             this.acted = false;
         return step;
     }
-    
+
     @Override
     protected boolean equalsAs(PossibleAction pa, boolean asOption) {
         // identity always true
         if (pa == this) return true;
         //  super checks both class identity and super class attributes
-        if (!super.equalsAs(pa, asOption)) return false; 
+        if (!super.equalsAs(pa, asOption)) return false;
 
         // finish if asOptions check, no asOption attributes
         if (asOption) return true;
 
         // check asAction attributes
-        MapCorrectionAction action = (MapCorrectionAction)pa; 
+        MapCorrectionAction action = (MapCorrectionAction)pa;
         return Objects.equal(this.location, action.location)
                 && Objects.equal(this.tiles, action.tiles)
                 && Objects.equal(this.orientation, action.orientation)
@@ -209,19 +211,19 @@ public class MapCorrectionAction extends CorrectionAction {
 
     @Override
     public String toString(){
-        return super.toString() + 
+        return super.toString() +
                 RailsObjects.stringHelper(this)
                 .addToStringOnlyActed("location", location)
                 .addToStringOnlyActed("tiles", tiles)
                 .addToStringOnlyActed("orientation", orientation)
         ;
     }
-    
+
     /** Deserialize */
     private void readObject(ObjectInputStream in) throws IOException,
             ClassNotFoundException {
         in.defaultReadObject();
-        
+
         if (Util.hasValue(correctionName))
             correctionType = CorrectionType.valueOf(correctionName);
 
@@ -230,7 +232,7 @@ public class MapCorrectionAction extends CorrectionAction {
 
         if (Util.hasValue(nextStepName))
             nextStep = ActionStep.valueOf(nextStepName);
-            
+
         MapManager mmgr = getRoot().getMapManager();
         if (Util.hasValue(locationCoordinates))
             location = mmgr.getHex(locationCoordinates);

--- a/src/main/java/rails/game/correct/MapCorrectionManager.java
+++ b/src/main/java/rails/game/correct/MapCorrectionManager.java
@@ -27,22 +27,22 @@ public final class MapCorrectionManager extends CorrectionManager {
     public static MapCorrectionManager create(GameManager parent) {
         return new MapCorrectionManager(parent);
     }
-    
+
     @Override
     public List<CorrectionAction> createCorrections() {
         List<CorrectionAction> actions = super.createCorrections();
 
         if (isActive()) {
             if (activeTileAction == null) {
-                activeTileAction = new MapCorrectionAction();
+                activeTileAction = new MapCorrectionAction(getRoot());
             }
             actions.add(activeTileAction);
             // FIXME: This is a workaround to get the LayTile and LayToken actions created from inside the CorrectionManager
-            LayTile tileAction = new LayTile(LayTile.CORRECTION);
+            LayTile tileAction = new LayTile(getRoot(), LayTile.CORRECTION);
             getParent().getPossibleActions().add(tileAction);
             for (PublicCompany company:getRoot().getCompanyManager().getAllPublicCompanies()) {
                 if (!company.isClosed() && company.hasLaidHomeBaseTokens() && company.getNumberOfFreeBaseTokens() > 0) {
-                    LayBaseToken tokenAction = new LayBaseToken(LayBaseToken.CORRECTION);
+                    LayBaseToken tokenAction = new LayBaseToken(getRoot(), LayBaseToken.CORRECTION);
                     tokenAction.setCompany(company);
                     getParent().getPossibleActions().add(tokenAction);
                 }
@@ -80,7 +80,7 @@ public final class MapCorrectionManager extends CorrectionManager {
         String errMsg = null;
         while (true) {
             // check if chosenTile is still available (not for preprinted)
-            // FIXME: Check if this is still correct (Rails 2.0), removed that check as all 
+            // FIXME: Check if this is still correct (Rails 2.0), removed that check as all
             // tiles have external id defined
             if (chosenTile != null // && rails.util.Util.hasValue(chosenTile.toText())
                     && chosenTile != hex.getCurrentTile()
@@ -187,7 +187,7 @@ public final class MapCorrectionManager extends CorrectionManager {
                 return execute(action);
             }
         case FINISHED:
-            
+
 
             // lays tile
             HexSide orientation = HexSide.get(action.getOrientation());

--- a/src/main/java/rails/game/correct/OperatingCost.java
+++ b/src/main/java/rails/game/correct/OperatingCost.java
@@ -5,13 +5,14 @@ import java.io.ObjectInputStream;
 
 import com.google.common.base.Objects;
 
+import net.sf.rails.game.RailsRoot;
 import rails.game.action.PossibleAction;
 import rails.game.action.PossibleORAction;
 import net.sf.rails.util.RailsObjects;
 import net.sf.rails.util.Util;
 
 /**
- * OR action for no map mode 
+ * OR action for no map mode
  * mirrors operating actions like tile and token lays, but
  * only changes the cash position of the public company
 
@@ -20,10 +21,10 @@ import net.sf.rails.util.Util;
 public class OperatingCost extends PossibleORAction {
 
     public enum OCType {LAY_TILE, LAY_BASE_TOKEN};
-    
+
     /** The Constant serialVersionUID. */
     public static final long serialVersionUID = 2L;
-    
+
     /* Preconditions */
 
     /** operating cost type (as tile lay, token lay etc.) */
@@ -31,33 +32,31 @@ public class OperatingCost extends PossibleORAction {
 
     /** suggested costs */
     private int suggestedCost;
-    
+
     /** maximum costs */
     private int maximumCost;
-    
+
     /** allow free entry */
     private boolean freeEntryAllowed;
-    
+
     /* Postconditions */
 
     /** selected cash amount */
-    private int operatingCost; 
+    private int operatingCost;
 
    /**
     * Instantiates an operating costs action
-    * 
+    *
     * @param pc Public Company
     */
-   public OperatingCost(OCType ot, int ocCosts, boolean freeEntry) {
-       
-       super();
-
+   public OperatingCost(RailsRoot root, OCType ot, int ocCosts, boolean freeEntry) {
+       super(root);
        operatingCostType = ot;
        suggestedCost = ocCosts;
        freeEntryAllowed = freeEntry;
        maximumCost = company.getCash();
    }
-   
+
    public boolean isFreeEntryAllowed() {
        return freeEntryAllowed;
    }
@@ -76,13 +75,13 @@ public class OperatingCost extends PossibleORAction {
    public OCType getOCType(){
        return operatingCostType;
    }
-   
+
    @Override
    protected boolean equalsAs(PossibleAction pa, boolean asOption) {
        // identity always true
        if (pa == this) return true;
        //  super checks both class identity and super class attributes
-       if (!super.equalsAs(pa, asOption)) return false; 
+       if (!super.equalsAs(pa, asOption)) return false;
 
        // check asOption attributes
        OperatingCost action = (OperatingCost) pa;
@@ -91,19 +90,19 @@ public class OperatingCost extends PossibleORAction {
                && Objects.equal(this.maximumCost, action.maximumCost)
                && Objects.equal(this.freeEntryAllowed, action.freeEntryAllowed)
        ;
-       
+
        // finish if asOptions check
        if (asOption) return options;
-       
+
        // check asAction attributes
        return options
                && Objects.equal(this.operatingCost, action.operatingCost)
        ;
     }
-    
+
    @Override
    public String toString() {
-       return super.toString() + 
+       return super.toString() +
                RailsObjects.stringHelper(this)
                    .addToString("operatingCostType", operatingCostType)
                    .addToString("suggestedCost", suggestedCost)
@@ -113,7 +112,7 @@ public class OperatingCost extends PossibleORAction {
                    .toString()
        ;
    }
-   
+
     /** Deserialize */
     private void readObject(ObjectInputStream in) throws IOException,
             ClassNotFoundException {

--- a/src/main/java/rails/game/specific/_1835/FoldIntoPrussian.java
+++ b/src/main/java/rails/game/specific/_1835/FoldIntoPrussian.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import net.sf.rails.game.RailsRoot;
 import rails.game.action.PossibleAction;
 import net.sf.rails.game.Company;
 import net.sf.rails.game.CompanyManager;
@@ -20,8 +21,8 @@ import com.google.common.base.Objects;
 public class FoldIntoPrussian extends PossibleAction {
 
     // Server settings
-    protected transient List<Company> foldableCompanies = null;
-    protected String foldableCompanyNames = null;
+    protected transient List<Company> foldableCompanies;
+    protected String foldableCompanyNames;
 
     // Client settings
     protected transient List<Company> foldedCompanies = null;
@@ -29,14 +30,14 @@ public class FoldIntoPrussian extends PossibleAction {
 
     public static final long serialVersionUID = 1L;
 
-    public FoldIntoPrussian(List<Company> companies) {
-        super(null); // not defined by an activity yet
+    public FoldIntoPrussian(RailsRoot root, List<Company> companies) {
+        super(root); // not defined by an activity yet
         this.foldableCompanies = companies;
         foldableCompanyNames = Util.joinNamesWithDelimiter(foldableCompanies, ",");
     }
 
     public FoldIntoPrussian(Company company) {
-        this (Arrays.asList(new Company[] {company}));
+        this (company.getRoot(), Arrays.asList(company));
     }
 
     public List<Company> getFoldedCompanies() {
@@ -69,21 +70,21 @@ public class FoldIntoPrussian extends PossibleAction {
         // identity always true
         if (pa == this) return true;
         //  super checks both class identity and super class attributes
-        if (!super.equalsAs(pa, asOption)) return false; 
+        if (!super.equalsAs(pa, asOption)) return false;
 
         // check asOption attributes
-        FoldIntoPrussian action = (FoldIntoPrussian)pa; 
-        boolean options = 
+        FoldIntoPrussian action = (FoldIntoPrussian)pa;
+        boolean options =
                 Objects.equal(this.foldableCompanies, action.foldableCompanies) ||
                     // additional conditions required as there is no sorting defined in old save files
                     this.foldableCompanies != null && action.foldableCompanies != null
                     && this.foldableCompanies.containsAll(action.foldableCompanies)
                     && action.foldableCompanies.containsAll(this.foldableCompanies)
         ;
-        
+
         // finish if asOptions check
         if (asOption) return options;
-        
+
         // check asAction attributes
         return options
                 && Objects.equal(this.foldedCompanies, action.foldedCompanies) ||
@@ -96,18 +97,18 @@ public class FoldIntoPrussian extends PossibleAction {
 
     @Override
     public String toString() {
-        return super.toString() + 
+        return super.toString() +
                 RailsObjects.stringHelper(this)
                     .addToString("foldableCompanies", foldableCompanies)
                     .addToStringOnlyActed("foldedCompanies", foldedCompanies)
                     .toString()
         ;
     }
-    
+
     /** Deserialize */
     private void readObject(ObjectInputStream in) throws IOException,
             ClassNotFoundException {
-        
+
         Company company;
 
         in.defaultReadObject();

--- a/src/main/java/rails/game/specific/_1837/FoldIntoHungary.java
+++ b/src/main/java/rails/game/specific/_1837/FoldIntoHungary.java
@@ -4,17 +4,18 @@ import java.util.List;
 
 import net.sf.rails.game.Company;
 
+import net.sf.rails.game.RailsRoot;
 import rails.game.action.FoldIntoNational;
 
 public class FoldIntoHungary extends FoldIntoNational {
 
     public static final long serialVersionUID = 1L;
 
-    public FoldIntoHungary(List<Company> companies) {
-        super(companies);
+    public FoldIntoHungary(RailsRoot root, List<Company> companies) {
+        super(root, companies);
     }
 
-    public FoldIntoHungary(Company company) {
+    public FoldIntoHungary(RailsRoot root, Company company) {
         super(company);
     }
 

--- a/src/main/java/rails/game/specific/_1837/FoldIntoKuK.java
+++ b/src/main/java/rails/game/specific/_1837/FoldIntoKuK.java
@@ -4,17 +4,18 @@ import java.util.List;
 
 import net.sf.rails.game.Company;
 
+import net.sf.rails.game.RailsRoot;
 import rails.game.action.FoldIntoNational;
 
 public class FoldIntoKuK extends FoldIntoNational {
 
     public static final long serialVersionUID = 1L;
 
-    public FoldIntoKuK(List<Company> companies) {
-        super(companies);
+    public FoldIntoKuK(RailsRoot root, List<Company> companies) {
+        super(root, companies);
     }
 
-    public FoldIntoKuK(Company company) {
+    public FoldIntoKuK(RailsRoot root, Company company) {
         super(company);
     }
 

--- a/src/main/java/rails/game/specific/_1837/FoldIntoSuedbahn.java
+++ b/src/main/java/rails/game/specific/_1837/FoldIntoSuedbahn.java
@@ -5,17 +5,18 @@ import java.util.List;
 
 import net.sf.rails.game.Company;
 
+import net.sf.rails.game.RailsRoot;
 import rails.game.action.FoldIntoNational;
 
 public class FoldIntoSuedbahn extends FoldIntoNational {
 
     public static final long serialVersionUID = 1L;
 
-    public FoldIntoSuedbahn(List<Company> companies) {
-        super(companies);
+    public FoldIntoSuedbahn(RailsRoot root, List<Company> companies) {
+        super(root, companies);
     }
 
-    public FoldIntoSuedbahn(Company company) {
+    public FoldIntoSuedbahn(RailsRoot root, Company company) {
         super(company);
     }
 

--- a/src/main/java/rails/game/specific/_1880/CloseInvestor_1880.java
+++ b/src/main/java/rails/game/specific/_1880/CloseInvestor_1880.java
@@ -11,24 +11,21 @@ import rails.game.action.PossibleORAction;
  * Rails 2.0: Updated equals and toString methods
  */
 public class CloseInvestor_1880 extends PossibleORAction {
-    
+
     private static final long serialVersionUID = 1L;
     private boolean treasuryToLinkedCompany = false;
     private boolean replaceToken = false;
-    
+
     public CloseInvestor_1880(Investor_1880 investor) {
+        super(investor.getRoot());
         this.company = investor;
         this.companyName = investor.getId();
-    }
-    
-    public CloseInvestor_1880() {
-        
     }
 
     public Investor_1880 getInvestor() {
         return (Investor_1880) company;
     }
-    
+
     public boolean getTreasuryToLinkedCompany() {
         return treasuryToLinkedCompany;
     }
@@ -45,19 +42,19 @@ public class CloseInvestor_1880 extends PossibleORAction {
         this.replaceToken = replaceToken;
     }
 
-    
+
     @Override
     protected boolean equalsAs(PossibleAction pa, boolean asOption) {
         // identity always true
         if (pa == this) return true;
         //  super checks both class identity and super class attributes
-        if (!super.equalsAs(pa, asOption)) return false; 
-        
+        if (!super.equalsAs(pa, asOption)) return false;
+
         // no asOption attributes
         if (asOption) return true;
 
         // check asAction attributes
-        CloseInvestor_1880 action = (CloseInvestor_1880)pa; 
+        CloseInvestor_1880 action = (CloseInvestor_1880)pa;
         return Objects.equal(this.treasuryToLinkedCompany, action.treasuryToLinkedCompany)
                 && Objects.equal(this.replaceToken, action.replaceToken)
         ;

--- a/src/main/java/rails/game/specific/_1880/ExchangeForCash.java
+++ b/src/main/java/rails/game/specific/_1880/ExchangeForCash.java
@@ -18,12 +18,12 @@ import rails.game.action.PossibleAction;
  * Rails 2.0: Updated equals and toString methods
  */
 public class ExchangeForCash extends PossibleAction {
-    private static final Map<String, Integer> CASH_VALUE_MAP = 
+    private static final Map<String, Integer> CASH_VALUE_MAP =
             ImmutableMap.of("2+2", 40, "3", 70, "3+3", 100);
 
-    private static final Map<String, Boolean> CHOICE_MAP = 
+    private static final Map<String, Boolean> CHOICE_MAP =
             ImmutableMap.of("2+2", true, "3", true, "3+3", false );
-           
+
     private static final long serialVersionUID = 1L;
     private transient Owner owner;
     private String ownerName;
@@ -31,9 +31,9 @@ public class ExchangeForCash extends PossibleAction {
     private transient boolean ownerHasChoice;
     // TODO: What is the function of exchangeCompany?
     private boolean exchangeCompany = false;
-    
+
     private ExchangeForCash(PrivateCompany company, int value, boolean ownerHasChoice) {
-        super(null); // not defined by an activity yet
+        super(company.getRoot()); // not defined by an activity yet
         this.owner = company.getOwner();
         this.ownerName = owner.getId();
         this.value = value;
@@ -48,7 +48,7 @@ public class ExchangeForCash extends PossibleAction {
         }
         return action;
     }
-    
+
 
     public String getOwnerName() {
         return ownerName;
@@ -57,7 +57,7 @@ public class ExchangeForCash extends PossibleAction {
     public int getCashValue() {
         return value;
     }
-    
+
     public boolean getOwnerHasChoice() {
         return ownerHasChoice;
     }
@@ -75,19 +75,19 @@ public class ExchangeForCash extends PossibleAction {
         // identity always true
         if (pa == this) return true;
         //  super checks both class identity and super class attributes
-        if (!super.equalsAs(pa, asOption)) return false; 
+        if (!super.equalsAs(pa, asOption)) return false;
 
         // check asOption attributes
-        ExchangeForCash action = (ExchangeForCash)pa; 
-        boolean options = 
+        ExchangeForCash action = (ExchangeForCash)pa;
+        boolean options =
                 Objects.equal(this.owner, action.owner)
                 && Objects.equal(this.value, action.value)
              // not stored:                && Objects.equal(this.ownerHasChoice, action.ownerHasChoice)
         ;
-        
+
         // finish if asOptions check
         if (asOption) return options;
-        
+
         // check asAction attributes
         return options
                 && Objects.equal(this.exchangeCompany, action.exchangeCompany)
@@ -96,20 +96,20 @@ public class ExchangeForCash extends PossibleAction {
 
     @Override
     public String toString() {
-        return super.toString() 
+        return super.toString()
                 + RailsObjects.stringHelper(this)
                 .addToString("owner", owner)
                 .addToString("value", value)
                 .addToStringOnlyActed("exchangeCompany", exchangeCompany)
         ;
     }
-    
+
     // deserialize to assign owner
     private void readObject(ObjectInputStream in) throws IOException,
             ClassNotFoundException {
         in.defaultReadObject();
         if (Util.hasValue(ownerName)) {
             owner = getRoot().getPlayerManager().getPlayerByName(ownerName);
-        } 
+        }
     }
 }

--- a/src/main/java/rails/game/specific/_1880/ForcedRocketExchange.java
+++ b/src/main/java/rails/game/specific/_1880/ForcedRocketExchange.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import com.google.common.base.Objects;
 import com.google.common.collect.Lists;
 
+import net.sf.rails.game.RailsRoot;
 import net.sf.rails.game.Train;
 import net.sf.rails.game.specific._1880.PublicCompany_1880;
 import net.sf.rails.util.RailsObjects;
@@ -19,27 +20,28 @@ import rails.game.action.PossibleORAction;
  */
 public class ForcedRocketExchange extends PossibleORAction {
     private static final long serialVersionUID = 1L;
-    
+
     // FIXME: Do not use strings to indicate companies
-    private transient List<String> companiesWithSpace = new ArrayList<String>();
-    private transient Map<String, List<Train>> companiesWithNoSpace = new HashMap<String, List<Train>>();
+    private final transient List<String> companiesWithSpace = new ArrayList<String>();
+    private final transient Map<String, List<Train>> companiesWithNoSpace = new HashMap<String, List<Train>>();
 
     private String companyToReceiveTrain;
     private String trainToReplace;
-        
-    public ForcedRocketExchange() {
+
+    public ForcedRocketExchange(RailsRoot root) {
+        super(root);
         companyToReceiveTrain = null;
         trainToReplace = null;
     }
 
     public void addCompanyWithSpace(PublicCompany_1880 company) {
         companiesWithSpace.add(company.getId());
-    }    
-    
+    }
+
     public List<String> getCompaniesWithSpace() {
         return companiesWithSpace;
     }
-    
+
     public boolean hasCompaniesWithSpace() {
         return (companiesWithSpace.isEmpty() == false);
     }
@@ -52,7 +54,7 @@ public class ForcedRocketExchange extends PossibleORAction {
     public Map<String, List<Train>> getCompaniesWithNoSpace() {
         return companiesWithNoSpace;
     }
-    
+
     public String getCompanyToReceiveTrain() {
         return companyToReceiveTrain;
     }
@@ -60,13 +62,13 @@ public class ForcedRocketExchange extends PossibleORAction {
     public void setCompanyToReceiveTrain(String companyToReceiveTrain) {
         this.companyToReceiveTrain = companyToReceiveTrain;
     }
-    
+
     public String getTrainToReplace() {
         return trainToReplace;
     }
-    
+
     public void setTrainToReplace(String trainToReplace) {
-        this.trainToReplace = trainToReplace;        
+        this.trainToReplace = trainToReplace;
     }
 
     @Override
@@ -74,13 +76,13 @@ public class ForcedRocketExchange extends PossibleORAction {
         // identity always true
         if (pa == this) return true;
         //  super checks both class identity and super class attributes
-        if (!super.equalsAs(pa, asOption)) return false; 
+        if (!super.equalsAs(pa, asOption)) return false;
 
         // no asOption attributes
         if (asOption) return true;
-        
+
         // check asAction attributes
-        ForcedRocketExchange action = (ForcedRocketExchange)pa; 
+        ForcedRocketExchange action = (ForcedRocketExchange)pa;
         return Objects.equal(this.companyToReceiveTrain, action.companyToReceiveTrain)
                 && Objects.equal(this.trainToReplace, action.trainToReplace)
         ;
@@ -89,12 +91,12 @@ public class ForcedRocketExchange extends PossibleORAction {
     @Override
     public String toString() {
         // TODO: does not print the static values, as they do not get serialized
-        return super.toString() 
+        return super.toString()
                 + RailsObjects.stringHelper(this)
                 .addToStringOnlyActed("companyToReceiveTrain", companyToReceiveTrain)
                 .addToStringOnlyActed("trainToReplace", trainToReplace)
                 .toString()
         ;
     }
-    
+
 }

--- a/src/main/java/rails/game/specific/_18EU/StartCompany_18EU.java
+++ b/src/main/java/rails/game/specific/_18EU/StartCompany_18EU.java
@@ -5,6 +5,7 @@ import java.io.ObjectInputStream;
 import java.util.ArrayList;
 import java.util.List;
 
+import net.sf.rails.util.GameLoader;
 import rails.game.action.PossibleAction;
 import rails.game.action.StartCompany;
 import net.sf.rails.game.CompanyManager;
@@ -51,10 +52,10 @@ public class StartCompany_18EU extends StartCompany {
 
         minorsToMerge = minors;
 
-        if (minorsToMerge != null) {
+        if ( minorsToMerge != null ) {
             StringBuilder b = new StringBuilder();
-            for (PublicCompany minor : minorsToMerge) {
-                if (b.length() > 0) b.append(",");
+            for ( PublicCompany minor : minorsToMerge ) {
+                if ( b.length() > 0 ) b.append(",");
                 b.append(minor.getId());
             }
             minorsToMergeNames = b.toString();
@@ -64,10 +65,10 @@ public class StartCompany_18EU extends StartCompany {
     public void setAvailableHomeStations(List<Stop> stations) {
         availableHomeStations = stations;
 
-        if (availableHomeStations != null) {
+        if ( availableHomeStations != null ) {
             StringBuilder b = new StringBuilder();
-            for (Stop station : availableHomeStations) {
-                if (b.length() > 0) b.append(",");
+            for ( Stop station : availableHomeStations ) {
+                if ( b.length() > 0 ) b.append(",");
                 b.append(station.getSpecificId());
             }
             availableHomeStationNames = b.toString();
@@ -94,9 +95,9 @@ public class StartCompany_18EU extends StartCompany {
     public Stop getSelectedHomeStation() {
         // use delayed selectedHomeStation initialization
         // as not all cities are defined immediately
-        if (selectedHomeStation == null && selectedHomeStationName != null) {
+        if ( selectedHomeStation == null && selectedHomeStationName != null ) {
             MapManager mapManager = getRoot().getMapManager();
-            String[] parts = parseStationName (selectedHomeStationName);
+            String[] parts = parseStationName(selectedHomeStationName);
             MapHex hex = mapManager.getHex(parts[0]);
             int stationId = Integer.parseInt(parts[1]);
             selectedHomeStation = hex.getRelatedStop(stationId);
@@ -113,72 +114,77 @@ public class StartCompany_18EU extends StartCompany {
     @Override
     protected boolean equalsAs(PossibleAction pa, boolean asOption) {
         // identity always true
-        if (pa == this) return true;
+        if ( pa == this ) return true;
         //  super checks both class identity and super class attributes
-        if (!super.equalsAs(pa, asOption)) return false;
+        if ( !super.equalsAs(pa, asOption) ) return false;
 
         // check asOption attributes
-        StartCompany_18EU action = (StartCompany_18EU)pa;
+        StartCompany_18EU action = (StartCompany_18EU) pa;
         boolean options =
                 Objects.equal(this.requestStartSpaces, action.requestStartSpaces)
-                // availableHomeStations does not work correctly, as here sometimes the station number deviate
-               // && RailsObjects.elementEquals(this.availableHomeStations, action.availableHomeStations)
-                && RailsObjects.elementEquals(this.minorsToMerge, action.minorsToMerge)
-        ;
+                        // availableHomeStations does not work correctly, as here sometimes the station number deviate
+                        // && RailsObjects.elementEquals(this.availableHomeStations, action.availableHomeStations)
+                        && RailsObjects.elementEquals(this.minorsToMerge, action.minorsToMerge);
 
         // finish if asOptions check
-        if (asOption) return options;
+        if ( asOption ) return options;
 
         // check asAction attributes
         return options
                 && Objects.equal(this.chosenMinor, action.chosenMinor)
                 && Objects.equal(this.selectedHomeStation, action.selectedHomeStation)
-        ;
+                ;
     }
 
     @Override
     public String toString() {
         return super.toString() +
                 RailsObjects.stringHelper(this)
-                    .addToString("minorsToMerge", minorsToMerge)
-                    .addToString("requestStartSpaces", requestStartSpaces)
-                    .addToString("availableHomeStations", availableHomeStations)
-                    .addToStringOnlyActed("chosenMinor", chosenMinor)
-                    .addToStringOnlyActed("selectedHomeStation", selectedHomeStation)
-                    .toString()
-        ;
+                        .addToString("minorsToMerge", minorsToMerge)
+                        .addToString("requestStartSpaces", requestStartSpaces)
+                        .addToString("availableHomeStations", availableHomeStations)
+                        .addToStringOnlyActed("chosenMinor", chosenMinor)
+                        .addToStringOnlyActed("selectedHomeStation", selectedHomeStation)
+                        .toString()
+                ;
 
     }
 
-    /** Deserialize */
+    /**
+     * Deserialize
+     */
     private void readObject(ObjectInputStream in) throws IOException,
-    ClassNotFoundException {
+            ClassNotFoundException {
 
         in.defaultReadObject();
 
-        CompanyManager cmgr = getCompanyManager();
-        if (minorsToMergeNames != null) {
+        RailsRoot root = ((GameLoader.RailsObjectInputStream) in).getRoot();
+
+        CompanyManager cmgr = root.getCompanyManager();
+        if ( minorsToMergeNames != null ) {
             minorsToMerge = new ArrayList<PublicCompany>();
-            for (String name : minorsToMergeNames.split(",")) {
+            for ( String name : minorsToMergeNames.split(",") ) {
                 minorsToMerge.add(cmgr.getPublicCompany(name));
             }
         }
-        if (chosenMinorName != null) {
+        if ( chosenMinorName != null ) {
             chosenMinor = cmgr.getPublicCompany(chosenMinorName);
         }
 
-        MapManager mapManager = RailsRoot.getInstance().getMapManager();
-        if (availableHomeStationNames != null) {
+        MapManager mapManager = root.getMapManager();
+        if ( availableHomeStationNames != null ) {
             availableHomeStations = new ArrayList<Stop>();
-            for (String cityName : availableHomeStationNames.split(",")) {
-                String[] parts = parseStationName (cityName);
+            for ( String cityName : availableHomeStationNames.split(",") ) {
+                String[] parts = parseStationName(cityName);
                 MapHex hex = mapManager.getHex(parts[0]);
                 int stationId = Integer.parseInt(parts[1]);
-                availableHomeStations.add (hex.getRelatedStop(stationId));
+                availableHomeStations.add(hex.getRelatedStop(stationId));
             }
         }
         // selectedHomeStation is delayed
     }
+
+    protected void finalizeLoad() { }
 
     private String[] parseStationName (String name) {
 

--- a/src/test/java/net/sf/rails/test/TestGame.java
+++ b/src/test/java/net/sf/rails/test/TestGame.java
@@ -127,7 +127,6 @@ public class TestGame extends TestCase {
             super.tearDown();
             testReport = null;
             expectedReport = null;
-            RailsRoot.clearInstance();
         }
     }
 

--- a/src/test/java/net/sf/rails/test/TestGameBuilder.java
+++ b/src/test/java/net/sf/rails/test/TestGameBuilder.java
@@ -32,8 +32,8 @@ public final class TestGameBuilder extends TestCase {
     private static int maxRecursionLevel = 5;
 
     // true = optimal for ant html reports, false = optimal for test runner
-    private static boolean extendedTestNames = true; 
-    
+    private static boolean extendedTestNames = true;
+
     static void saveGameReport(List<String> report, String reportFilename, boolean failed) {
         PrintWriter reportFile = null;
         try{
@@ -42,7 +42,7 @@ public final class TestGameBuilder extends TestCase {
             {
             System.err.print("Error: cannot open file " + reportFilename + " for report writing");
             }
-        if (reportFile != null) { 
+        if (reportFile != null) {
             for (String msg:report){
                 reportFile.println(msg);
             }
@@ -54,28 +54,28 @@ public final class TestGameBuilder extends TestCase {
             }
         }
     }
-    
-    
+
+
     private static void prepareGameReport(File gameFile, String reportFilename) {
-        
+
         RailsRoot root = null;
-        if (gameFile.exists()) { 
+        if (gameFile.exists()) {
             System.out.println("Found game at " + gameFile.getAbsolutePath());
             GameLoader gameLoader = new GameLoader();
             if (gameLoader.createFromFile(gameFile)) {
                 root = gameLoader.getRoot();
             }
         }
-        if (root != null) {  
+        if (root != null) {
             List<String> report = root.getReportManager().getReportBuffer().getAsList();
             saveGameReport(report, reportFilename, false);
         }
     }
 
-    
+
     // returns gameName if prepararion was successfull
     private static String prepareTestGame(File gameFile, boolean overrideReport){
-     
+
         // check preconditions
         if (!gameFile.exists() || !gameFile.isFile()) return null;
 
@@ -88,29 +88,28 @@ public final class TestGameBuilder extends TestCase {
                 Config.get("save.filename.extension"))) {
             gameName = fileName.substring(0,dot);
             String gamePath = gameFile.getParent();
-        
+
             // check if there is a reportfile
-            String reportFilename = gamePath + File.separator + gameName 
-                    + "." + Config.get("report.filename.extension"); 
+            String reportFilename = gamePath + File.separator + gameName
+                    + "." + Config.get("report.filename.extension");
             File reportFile = new File(reportFilename);
-            
+
             if (!reportFile.exists() || overrideReport) {
                 prepareGameReport(gameFile, reportFilename);
-                RailsRoot.clearInstance();
             }
         }
-        
+
         return gameName;
     }
-    
+
     private static TestSuite recursiveTestSuite(String rootPath, String dirPath, int level, boolean overrideReport){
 
         // completeDirPath
         String combinedDirPath = rootPath + File.separator + dirPath;
-        
+
         // assign directory
         File directory = new File(combinedDirPath);
-        
+
         // check if directory exists otherwise return null
         if (!directory.exists() || !directory.isDirectory()) return null;
 
@@ -121,11 +120,11 @@ public final class TestGameBuilder extends TestCase {
             suite = new TestSuite("Rails Tests");
         else
             suite = new TestSuite(directory.getName());
-        
-        // use filelist to sort 
+
+        // use filelist to sort
         List<String> filenameList = Arrays.asList(directory.list());
         Collections.sort(filenameList);
-        
+
         // add deeper directories
         for (String fn:filenameList) {
             File f = new File(combinedDirPath + File.separator + fn);
@@ -146,7 +145,7 @@ public final class TestGameBuilder extends TestCase {
             String gameName = prepareTestGame(f, overrideReport);
             if (gameName != null) {
                 String extendedGameName;
-                if (extendedTestNames) 
+                if (extendedTestNames)
                     extendedGameName = dirPath + File.separator + gameName;
                 else
                     extendedGameName = gameName;
@@ -154,46 +153,46 @@ public final class TestGameBuilder extends TestCase {
                 System.out.println("Added TestGame "+ extendedGameName);
             }
         }
-        
+
         return suite;
     }
-    
+
     /**
      * Builds test suite of all test games below the main test directory
      * @return created test suite for junit
      */
-    
+
     public static Test suite() {
-        
+
         ConfigManager.initConfiguration(true);
-        
-        // Main test directory 
+
+        // Main test directory
         File testDir = new File(Config.get("save.directory"));
-        
+
         // Create tests
         TestSuite suite = null;
         if (testDir.exists() && testDir.isDirectory()) {
             System.out.println("Test directory = " + testDir.getAbsolutePath());
             suite = recursiveTestSuite(testDir.getAbsolutePath(), "",  0, false);
         }
-        
+
         return suite;
     }
-    
-    
+
+
     /**
      * Run main to rebuild the report files.
      * Only use this if you know what you are doing
-     * 
-     * @param args a list of directories below the main test directory 
+     *
+     * @param args a list of directories below the main test directory
      */
     public static void main(String[] args) {
 
         ConfigManager.initConfiguration(true);
-    
-        // Main test directory 
+
+        // Main test directory
         String rootPath = Config.get("save.directory");
-        
+
         if (args != null && args.length > 0) {
             // commandline argument: only directories are possible
             System.out.println("Number of args: "+ args.length);
@@ -202,7 +201,7 @@ public final class TestGameBuilder extends TestCase {
                 recursiveTestSuite(rootPath, arg, 0, true);
         } else {
             // ask for directories to ovrerride
-            JPanel panel = new JPanel(); 
+            JPanel panel = new JPanel();
             JFileChooser chooser = new JFileChooser();
             chooser.setDialogTitle("Select directories and/or files to reset game reports");
             chooser.setCurrentDirectory(new File(rootPath));
@@ -212,7 +211,7 @@ public final class TestGameBuilder extends TestCase {
             chooser.setFileFilter(new FileFilter() {
                 public boolean accept(File f) {
                     return f.isDirectory() || f.getName().endsWith("." + Config.get("save.filename.extension"));
-                  } 
+                  }
                 public String getDescription()  {
                     return "Rails save files (*."+ Config.get("save.filename.extension") + ")" ;
                 }


### PR DESCRIPTION
This PR builds on #120 

The primary focus of this PR is to replace `RailsRoot` as a singleton/static instance. In most places the change was pretty clean but there were some `Action` classes that made references to the singleton and hence needed the `RailsRoot` passed in during object creation. In addition there were some changes to the deserialization logic but those already had access to the `RailsRoot` instance via the stream but instead were referencing it via the static method.

This PR also includes some other static variable/instance cleanups that were more minor in nature and seemed to be historical in nature and not really needing to be static with the current code base.

Note: this PR does *not* change all `Action` classes to include `RailsRoot` passed in during construction, only those that needed it. This could (should?) be a future PR such that we standardize those `Action` classes.

FYI I have 1 or 2 more PRs coming to "finish" cleanup of singleton/static usages were appropriate (ie still leaving things that are appropriate singletons such as the `ConfigurationManager`). Those PRs are currently "blocked" from submission by some of the other currently open PRs I have.