### PR TITLE
added directory check to open save game chooser for Windows

### DIFF
--- a/src/main/java/net/sf/rails/ui/swing/GameSetupController.java
+++ b/src/main/java/net/sf/rails/ui/swing/GameSetupController.java
@@ -220,7 +220,7 @@ public class GameSetupController {
             jfc.setFileFilter(new FileFilter() {
                 @Override
                 public boolean accept(File f) {
-                    return isOurs(f);
+                    return isOurs(f) || f.isDirectory();
                 }
 
                 @Override


### PR DESCRIPTION
Received a complaint that the recently added file display filter on the Open Saved Games file chooser on windows does not display folders (unlike the Mac where the folders are displayed).

This adds a directory check along with the check for our filter extensions