### PR TITLE
user notification of turn

### DIFF
--- a/src/main/java/net/sf/rails/ui/swing/GameUIManager.java
+++ b/src/main/java/net/sf/rails/ui/swing/GameUIManager.java
@@ -379,11 +379,17 @@ public class GameUIManager implements DialogOwner {
                         log.info("Relinquishing turn to {}", newPlayer.getId());
                     } else if (!wasMyTurn && myTurn) {
                         autoLoadPoller.setActive(false);
-                        setCurrentDialog(new MessageDialog(null, this,
-                                        (JFrame) activeWindow,
-                                        LocalText.getText("Message"),
-                                        LocalText.getText("YourTurn", localPlayerName)),
-                                null);
+
+                        if ( Taskbar.getTaskbar().isSupported(Taskbar.Feature.USER_ATTENTION) ) {
+                            Taskbar.getTaskbar().requestUserAttention(true, false);
+                        } else {
+                            setCurrentDialog(new MessageDialog(null, this,
+                                            (JFrame) activeWindow,
+                                            LocalText.getText("Message"),
+                                            LocalText.getText("YourTurn", localPlayerName)),
+                                    null);
+                        }
+
                         log.info("Resuming turn as {}", localPlayerName);
                     } else {
                         log.info("{} now has the turn", newPlayer.getId());


### PR DESCRIPTION
This PR adds user notification during auto-load/polling based on standard platform notifications. For instance on the Mac this will bounce the icon in the Dock.

Not all platforms support a system level notification from Java in which case it will fall back to the default "Your turn" dialog.