### PR TITLE
static report window & buttons learned about myTurn

### DIFF
--- a/src/main/java/net/sf/rails/common/ReportBuffer.java
+++ b/src/main/java/net/sf/rails/common/ReportBuffer.java
@@ -1,19 +1,20 @@
 package net.sf.rails.common;
 
+import java.util.Deque;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
+
 import net.sf.rails.game.RailsAbstractItem;
 import net.sf.rails.game.RailsItem;
 import net.sf.rails.game.state.ChangeReporter;
 import net.sf.rails.game.state.ChangeSet;
 import net.sf.rails.game.state.ChangeStack;
 import net.sf.rails.util.Util;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.util.Deque;
-import java.util.Queue;
 
 /**
  * ReportBuffer stores messages of the game progress.
@@ -32,9 +33,6 @@ public class ReportBuffer extends RailsAbstractItem implements ChangeReporter {
     // static data
     private final Deque<ReportSet> pastReports = Lists.newLinkedList();
     private final Deque<ReportSet> futureReports = Lists.newLinkedList();
-
-    // TODO: Remove waitQueue, see functions below
-    private final Queue<String> waitQueue = Lists.newLinkedList();
 
     private ChangeStack changeStack; // initialized via init()
 
@@ -160,23 +158,6 @@ public class ReportBuffer extends RailsAbstractItem implements ChangeReporter {
      */
     public static void add(RailsItem item, String message) {
         item.getRoot().getReportManager().getReportBuffer().addMessage(message);
-    }
-
-    // FIXME: Rails 2.0 Is it possible to remove the only usecase for 1856 escrow money?
-    @Deprecated
-    public static void addWaiting(RailsItem item, String message) {
-        item.getRoot().getReportManager().getReportBuffer().waitQueue.add(message);
-    }
-
-    @Deprecated
-    public static void getAllWaiting(RailsItem item) {
-        ReportBuffer reportBuffer = item.getRoot().getReportManager().getReportBuffer();
-
-        for (String message : reportBuffer.waitQueue) {
-            reportBuffer.addMessage(message);
-        }
-
-        reportBuffer.waitQueue.clear();
     }
 
     public interface Observer {

--- a/src/main/java/net/sf/rails/game/financial/StockRound.java
+++ b/src/main/java/net/sf/rails/game/financial/StockRound.java
@@ -1,13 +1,24 @@
 package net.sf.rails.game.financial;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.SortedSet;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import net.sf.rails.game.StartRound;
-import rails.game.action.*;
-import net.sf.rails.common.*;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSetMultimap;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Sets;
+import com.google.common.collect.SortedMultiset;
+
+import net.sf.rails.common.DisplayBuffer;
+import net.sf.rails.common.GameOption;
+import net.sf.rails.common.GuiDef;
+import net.sf.rails.common.LocalText;
+import net.sf.rails.common.ReportBuffer;
 import net.sf.rails.game.GameDef;
 import net.sf.rails.game.GameManager;
 import net.sf.rails.game.Player;
@@ -15,18 +26,26 @@ import net.sf.rails.game.PlayerManager;
 import net.sf.rails.game.PrivateCompany;
 import net.sf.rails.game.PublicCompany;
 import net.sf.rails.game.Round;
-import net.sf.rails.game.GameDef.Parm;
 import net.sf.rails.game.model.PortfolioModel;
-import net.sf.rails.game.round.Activity;
-import net.sf.rails.game.special.*;
-import net.sf.rails.game.state.*;
+import net.sf.rails.game.special.ExchangeForShare;
+import net.sf.rails.game.special.SpecialProperty;
+import net.sf.rails.game.state.ArrayListState;
+import net.sf.rails.game.state.BooleanState;
 import net.sf.rails.game.state.Currency;
-
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.ImmutableSetMultimap;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Sets;
-import com.google.common.collect.SortedMultiset;
+import net.sf.rails.game.state.GenericState;
+import net.sf.rails.game.state.HashMapState;
+import net.sf.rails.game.state.HashSetState;
+import net.sf.rails.game.state.IntegerState;
+import net.sf.rails.game.state.MoneyOwner;
+import net.sf.rails.game.state.Owner;
+import net.sf.rails.game.state.Portfolio;
+import rails.game.action.BuyCertificate;
+import rails.game.action.NullAction;
+import rails.game.action.PossibleAction;
+import rails.game.action.RequestTurn;
+import rails.game.action.SellShares;
+import rails.game.action.StartCompany;
+import rails.game.action.UseSpecialProperty;
 
 
 /**
@@ -832,7 +851,6 @@ public class StockRound extends Round {
                 shares,
                 cert.getShare(),
                 priceRecipient.getId()));
-        ReportBuffer.getAllWaiting(this);
 
         checkFlotation(company);
 
@@ -1010,7 +1028,6 @@ public class StockRound extends Round {
                     from.getName(),
                     Bank.format(this, cost)));
         }
-        ReportBuffer.getAllWaiting(this);
 
         PublicCertificate cert2;
         for (int i = 0; i < number; i++) {

--- a/src/main/java/net/sf/rails/ui/swing/GameUIManager.java
+++ b/src/main/java/net/sf/rails/ui/swing/GameUIManager.java
@@ -283,11 +283,9 @@ public class GameUIManager implements DialogOwner {
         FXStockChartWindow.launch(this);
 
         splashWindow.notifyOfStep(SplashWindow.STEP_REPORT_WINDOW);
-        if (Config.get("report.window.type").equalsIgnoreCase("static")) {
-            // reportWindow = new ReportWindowStatic(this);
-        } else {
-            reportWindow = new ReportWindow(this);
-        }
+
+        boolean staticReportWindow = Config.get("report.window.type").equalsIgnoreCase("static");
+        reportWindow = new ReportWindow(this, staticReportWindow);
 
         orWindow = new ORWindow(this, splashWindow);
         orUIManager = orWindow.getORUIManager();
@@ -400,10 +398,10 @@ public class GameUIManager implements DialogOwner {
         updateUI();
 
         statusWindow.initGameActions();
+        reportWindow.setActions();
         if (!myTurn) return true;
         statusWindow.setGameActions();
         statusWindow.setCorrectionMenu();
-        reportWindow.setActions();
 
         // Is this perhaps the right place to display messages...?
         if (getDisplayBuffer().getAutoDisplay()) {
@@ -864,6 +862,10 @@ public class GameUIManager implements DialogOwner {
         return autoLoadPoller != null && autoLoadPoller.getStatus() == AutoLoadPoller.ON;
     }
 
+    public boolean isMyTurn() {
+        return myTurn;
+    }
+
     /**
      * Stub, can be overridden by subclasses
      */
@@ -940,7 +942,6 @@ public class GameUIManager implements DialogOwner {
             processAction(exportAction);
         }
     }
-
 
     public void saveGame(GameAction saveAction) {
         // copy latest report buffer entries to clipboard

--- a/src/main/resources/data/Properties.xml
+++ b/src/main/resources/data/Properties.xml
@@ -51,7 +51,7 @@
 	<Section name="Windows">
 		<Property name="report.window.type" type="LIST" values="static,dynamic" />
 		<Property name="report.window.open" type="BOOLEAN" />
-		<Property name="report.window.editable" type="BOOLEAN" />
+<!--		<Property name="report.window.editable" type="BOOLEAN" />-->
 		<Property name="stockchart.window.open" type="BOOLEAN" />
 		<Property name="or.window.dockablePanels" type="BOOLEAN" />
 		<Property name="splash.window.open" type="BOOLEAN" />


### PR DESCRIPTION
This PR adds a configuration option that makes the report window "static" in that you can not click on a link to rollback/undo to that point.

In addition, it fixes a bug when loading a saved game in that the top of the report window displays the timewarp active buttons and text even though you aren't actually in a timewarp.

Finally the report window learns about myTurn and disallows undo when it is not your turn (but should still allow undo via moderator). This addresses an issue where someone executes an undo after their turn has finished and the file was written at which point the other users may have loaded the file and hence causes load issues when the previous player redoes their turn.

If a user really needs to rollback their turn they should coordinate it with the other players and re-open their original game file and start from there.