### PR TITLE
statics: cert manager

### DIFF
--- a/src/main/java/net/sf/rails/game/CertificateManager.java
+++ b/src/main/java/net/sf/rails/game/CertificateManager.java
@@ -1,0 +1,24 @@
+package net.sf.rails.game;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import net.sf.rails.game.financial.PublicCertificate;
+
+public class CertificateManager  extends RailsManager {
+
+    protected static Map<String, PublicCertificate> certMap = new HashMap<>();
+
+    protected CertificateManager(RailsItem parent, String id) {
+        super(parent, id);
+    }
+
+    public void addCertificate(String certId, PublicCertificate certificate) {
+        certMap.put(certId, certificate);
+    }
+
+    public PublicCertificate getCertificate(String certId) {
+        return certMap.get(certId);
+    }
+
+}

--- a/src/main/java/net/sf/rails/game/RailsRoot.java
+++ b/src/main/java/net/sf/rails/game/RailsRoot.java
@@ -46,6 +46,7 @@ public class RailsRoot extends Root implements RailsItem {
     private TileManager tileManager;
     private RevenueManager revenueManager;
     private Bank bank;
+    private CertificateManager certificateManager;
 
     // Other Managers
     private ReportManager reportManager;
@@ -99,6 +100,8 @@ public class RailsRoot extends Root implements RailsItem {
             tileManager = (TileManager) component;
         } else if (component instanceof RevenueManager) {
             revenueManager = (RevenueManager) component;
+        } else if (component instanceof CertificateManager) {
+            certificateManager = (CertificateManager) component;
         }
     }
 
@@ -130,6 +133,9 @@ public class RailsRoot extends Root implements RailsItem {
         // TODO: Can this be merged above?
         playerManager.init();
 
+        if ( certificateManager == null ) {
+            certificateManager = new CertificateManager(this, "CertificateManager");
+        }
         try {
             playerManager.finishConfiguration(this);
             companyManager.finishConfiguration(this);
@@ -147,6 +153,7 @@ public class RailsRoot extends Root implements RailsItem {
             DisplayBuffer.add(this, e.getMessage());
             return false;
         }
+
         return true;
     }
 
@@ -209,6 +216,9 @@ public class RailsRoot extends Root implements RailsItem {
         return reportManager;
     }
 
+    public CertificateManager getCertificateManager() {
+        return certificateManager;
+    }
 
     /**
      * @return the gameName

--- a/src/main/java/net/sf/rails/game/financial/PublicCertificate.java
+++ b/src/main/java/net/sf/rails/game/financial/PublicCertificate.java
@@ -89,10 +89,6 @@ public class PublicCertificate extends RailsOwnableItem<PublicCertificate> imple
     /** Index within company (to be maintained in the IPO) */
     protected int indexInCompany;
 
-    /** A map allowing to find certificates by unique id */
-    // FIXME: Remove static map, replace by other location mechanisms
-    protected static Map<String, PublicCertificate> certMap = new HashMap<>();
-
     private static final Logger log = LoggerFactory.getLogger(PublicCertificate.class);
 
     // TODO: Rewrite constructors
@@ -131,7 +127,7 @@ public class PublicCertificate extends RailsOwnableItem<PublicCertificate> imple
     /** Set the certificate's unique ID, for use in deserializing */
     public void setUniqueId(String name, int index) {
         certId = name + "-" + index;
-        certMap.put(certId, this);
+        getRoot().getCertificateManager().addCertificate(certId, this);
     }
 
     /** Set the certificate's unique ID */
@@ -142,11 +138,6 @@ public class PublicCertificate extends RailsOwnableItem<PublicCertificate> imple
     public int getIndexInCompany() {
         return indexInCompany;
     }
-
-    public static PublicCertificate getByUniqueId(String certId) {
-        return certMap.get(certId);
-    }
-
 
     // FIXME: There is no guarantee that the parent of a certificate portfolio is a portfolioModel
     // Replace that by something that works

--- a/src/main/java/rails/game/action/BuyCertificate.java
+++ b/src/main/java/rails/game/action/BuyCertificate.java
@@ -182,7 +182,7 @@ public class BuyCertificate extends PossibleAction {
         if (certUniqueId != null) {
             // Old style
             certUniqueId = companyManager.checkAliasInCertId(certUniqueId);
-            certificate = PublicCertificate.getByUniqueId(certUniqueId);
+            certificate = getRoot().getCertificateManager().getCertificate(certUniqueId);
             // TODO: This function needs a compatible replacement
             from = root.getGameManager().getPortfolioByName(fromName);
             company = certificate.getCompany();


### PR DESCRIPTION
Addition of `CertificateManager` class to address a `FIXME` comment removing a static `Map` in `PublicCertificate` that was used to store all certs for lookup and referenced during deserialization. This moves storage and lookup of those certs into the `CertificationManager` class which can then be referenced during deserialization via `RailsRoot` instead of via static methods.