### PR TITLE
auto-load/reload serialization fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,6 +72,8 @@ dependencies {
     implementation 'org.apache.httpcomponents:httpclient:4.5.12'
     implementation 'org.apache.commons:commons-lang3:3.10'
     implementation 'org.apache.commons:commons-text:1.8'
+    // https://www.jetbrains.com/help/idea/annotating-source-code.html
+    implementation 'org.jetbrains:annotations:16.0.2'
 
     testImplementation 'junit:junit:4.13'
     testImplementation 'org.easytesting:fest-assert-core:2.0M10'

--- a/src/main/java/net/sf/rails/game/specific/_1835/PrussianFormationRound.java
+++ b/src/main/java/net/sf/rails/game/specific/_1835/PrussianFormationRound.java
@@ -73,8 +73,7 @@ public class PrussianFormationRound extends StockRound {
         mergePr = !prussianIsComplete(gameManager);
 
         ReportBuffer.add(this, LocalText.getText("StartFormationRound", PR_ID));
-        log.debug("StartPr="+startPr+" forcedStart="+forcedStart
-                +" mergePr="+mergePr+" forcedMerge="+forcedMerge);
+        log.debug("StartPr={} forcedStart={} mergePr={} forcedMerge={}", startPr, forcedStart, mergePr, forcedMerge);
 
         step = startPr ? Step.START : Step.MERGE;
 
@@ -89,9 +88,8 @@ public class PrussianFormationRound extends StockRound {
         }
 
         if (step == Step.MERGE) {
-            startingPlayer
-            = ((GameManager_1835)gameManager).getPrussianFormationStartingPlayer();
-            log.debug("Original Prussian starting player was "+startingPlayer.getId());
+            startingPlayer = ((GameManager_1835)gameManager).getPrussianFormationStartingPlayer();
+            log.debug("Original Prussian starting player was {}", startingPlayer.getId());
             setCurrentPlayer(startingPlayer);
             if (forcedMerge) {
                 Set<SpecialProperty> sps;
@@ -144,7 +142,7 @@ public class PrussianFormationRound extends StockRound {
         } else if (step == Step.DISCARD_TRAINS) {
 
             if (prussian.getNumberOfTrains() > prussian.getCurrentTrainLimit()) {
-                log.debug("+++ PR has "+prussian.getNumberOfTrains()+", limit is "+prussian.getCurrentTrainLimit());
+                log.debug("+++ PR has {}, limit is {}", prussian.getNumberOfTrains(), prussian.getCurrentTrainLimit());
                 possibleActions.add(new DiscardTrain(prussian,
                         prussian.getPortfolioModel().getUniqueTrains(), true));
             }

--- a/src/main/java/net/sf/rails/game/specific/_18AL/AssignNamedTrains.java
+++ b/src/main/java/net/sf/rails/game/specific/_18AL/AssignNamedTrains.java
@@ -6,6 +6,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
+import org.jetbrains.annotations.NotNull;
+
 import com.google.common.base.Objects;
 
 import net.sf.rails.game.RailsRoot;
@@ -23,61 +25,52 @@ import rails.game.action.UseSpecialProperty;
 // TODO: Rails 2.0 This seems a pretty complicated action. Is this really required for the task?
 public class AssignNamedTrains extends UseSpecialProperty {
 
-    transient private List<NameableTrain> nameableTrains;
-    private String[] trainIds;
-    private int numberOfTrains;
-    private int numberOfTokens;
+    final transient private List<NameableTrain> nameableTrains = new ArrayList<>();
+    private final String[] trainIds;
 
-    transient private List<NameableTrain> preTrainPerToken;
-    private String[] preTrainds;
+    final transient private List<NameableTrain> preTrainPerToken = new ArrayList<>();
+    private final String[] preTrainds;
 
-    transient private List<NameableTrain> postTrainPerToken;
-    private String[] postTrainds;
+    transient private List<NameableTrain> postTrainPerToken = new ArrayList<>();
+    private final String[] postTrainds;
 
     public static final long serialVersionUID = 1L;
 
-    public AssignNamedTrains(NameTrains namedTrainsSpecialProperty,
-            Set<Train> trains) {
+    public AssignNamedTrains(NameTrains namedTrainsSpecialProperty, @NotNull Set<Train> trains) {
         super(namedTrainsSpecialProperty);
 
-        numberOfTrains = trains.size();
+        int numberOfTrains = trains.size();
         List<NamedTrainToken> tokens = namedTrainsSpecialProperty.getTokens();
-        numberOfTokens = tokens.size();
+        int numberOfTokens = tokens.size();
 
-        nameableTrains = new ArrayList<NameableTrain>(numberOfTrains);
         for (Train train : trains) {
             nameableTrains.add((NameableTrain) train);
         }
-        preTrainPerToken = new ArrayList<NameableTrain>(numberOfTokens);
-        postTrainPerToken = new ArrayList<NameableTrain>(numberOfTokens);
-
         trainIds = new String[numberOfTrains];
         preTrainds = new String[numberOfTokens];
         postTrainds = new String[numberOfTokens];
 
-        for (int i = 0; i < numberOfTokens; i++) {
+        for ( int i = 0; i < numberOfTokens; i++) {
             preTrainPerToken.add(null);
         }
 
-        if (trains != null) {
-            int trainIndex = 0;
-            int tokenIndex;
-            for (NameableTrain train : nameableTrains) {
-                trainIds[trainIndex] = train.getId();
-                NamedTrainToken token = train.getNameToken();
-                if (token != null) {
-                    preTrainPerToken.set(tokens.indexOf(token), train);
-                    tokenIndex = tokens.indexOf(token);
-                    preTrainds[tokenIndex] = train.getId();
-                }
-                trainIndex++;
+        int trainIndex = 0;
+        int tokenIndex;
+        for (NameableTrain train : nameableTrains) {
+            trainIds[trainIndex] = train.getId();
+            NamedTrainToken token = train.getNameToken();
+            if (token != null) {
+                preTrainPerToken.set(tokens.indexOf(token), train);
+                tokenIndex = tokens.indexOf(token);
+                preTrainds[tokenIndex] = train.getId();
             }
+            trainIndex++;
         }
     }
 
     @Override
     public String toMenu() {
-        return ((NameTrains) specialProperty).toMenu();
+        return specialProperty.toMenu();
     }
 
     public List<NamedTrainToken> getTokens() {
@@ -149,16 +142,12 @@ public class AssignNamedTrains extends UseSpecialProperty {
 
         TrainManager trainManager = root.getTrainManager();
 
-        // TODO: verify we should create this array (see issue found with LayBaseToken)
-        nameableTrains = new ArrayList<>();
         if (trainIds != null) {
             for (String trainId : trainIds) {
                 nameableTrains.add((NameableTrain) trainManager.getTrainByUniqueId(trainId));
             }
         }
 
-        // TODO: verify we should create this array (see issue found with LayBaseToken)
-        preTrainPerToken = new ArrayList<>(numberOfTrains);
         if (preTrainds != null) {
             for (String trainId : preTrainds) {
                 if (trainId != null && trainId.length() > 0) {
@@ -170,8 +159,6 @@ public class AssignNamedTrains extends UseSpecialProperty {
             }
         }
 
-        // TODO: verify we should create this array (see issue found with LayBaseToken)
-        postTrainPerToken = new ArrayList<>(numberOfTrains);
         if (postTrainds != null) {
             for (String trainId : postTrainds) {
                 if (trainId != null && trainId.length() > 0) {

--- a/src/main/java/rails/game/action/DiscardTrain.java
+++ b/src/main/java/rails/game/action/DiscardTrain.java
@@ -5,6 +5,8 @@ import java.io.ObjectInputStream;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.jetbrains.annotations.NotNull;
+
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableSet;
 
@@ -23,7 +25,7 @@ public class DiscardTrain extends PossibleORAction {
 
     // Server settings
     transient private Set<Train> ownedTrains;
-    private String[] ownedTrainsUniqueIds;
+    private final String[] ownedTrainsUniqueIds;
 
     /**
      * True if discarding trains is mandatory
@@ -36,12 +38,12 @@ public class DiscardTrain extends PossibleORAction {
 
     public static final long serialVersionUID = 1L;
 
-    public DiscardTrain(PublicCompany company, Set<Train> trains) {
+    public DiscardTrain(PublicCompany company, @NotNull Set<Train> ownedTrains) {
         super(company.getRoot());
-        this.ownedTrains = trains;
-        this.ownedTrainsUniqueIds = new String[trains.size()];
+        this.ownedTrains = ownedTrains;
+        this.ownedTrainsUniqueIds = new String[ownedTrains.size()];
         int i = 0;
-        for ( Train train : trains ) {
+        for ( Train train : ownedTrains ) {
             ownedTrainsUniqueIds[i++] = train.getId();
         }
         this.company = company;
@@ -123,8 +125,8 @@ public class DiscardTrain extends PossibleORAction {
             discardedTrain = trainManager.getTrainByUniqueId(discardedTrainUniqueId);
         }
 
+        ownedTrains = new HashSet<>();
         if ( ownedTrainsUniqueIds != null && ownedTrainsUniqueIds.length > 0 ) {
-            ownedTrains = new HashSet<>();
             for ( String ownedTrainsUniqueId : ownedTrainsUniqueIds ) {
                 ownedTrains.add(trainManager.getTrainByUniqueId(ownedTrainsUniqueId));
             }

--- a/src/main/java/rails/game/action/FoldIntoNational.java
+++ b/src/main/java/rails/game/action/FoldIntoNational.java
@@ -9,6 +9,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import org.jetbrains.annotations.NotNull;
+
 import net.sf.rails.game.Company;
 import net.sf.rails.game.CompanyManager;
 import net.sf.rails.game.RailsRoot;
@@ -24,8 +26,8 @@ import com.google.common.base.Objects;
 public class FoldIntoNational extends PossibleAction {
 
     // Server settings
-    protected transient List<Company> foldableCompanies = null;
-    protected String foldableCompanyNames = null;
+    protected transient List<Company> foldableCompanies;
+    protected String foldableCompanyNames;
 
     // Client settings
     protected transient List<Company> foldedCompanies = null;
@@ -33,9 +35,9 @@ public class FoldIntoNational extends PossibleAction {
 
     public static final long serialVersionUID = 1L;
 
-    public FoldIntoNational(RailsRoot root, List<Company> companies) {
+    public FoldIntoNational(RailsRoot root, @NotNull List<Company> foldableCompanies) {
         super(root); // not defined by an activity yet
-        this.foldableCompanies = companies;
+        this.foldableCompanies = foldableCompanies;
         foldableCompanyNames = Util.joinNamesWithDelimiter(foldableCompanies, ",");
     }
 
@@ -52,7 +54,6 @@ public class FoldIntoNational extends PossibleAction {
         this.foldedCompanies = foldedCompanies;
         foldedCompanyNames = Util.joinNamesWithDelimiter (foldedCompanies, ",");
     }
-
 
     public List<Company> getFoldableCompanies() {
         return foldableCompanies;
@@ -113,10 +114,10 @@ public class FoldIntoNational extends PossibleAction {
         in.defaultReadObject();
 
         Company company;
-
         CompanyManager cmgr = getCompanyManager();
+
+        foldableCompanies = new ArrayList<>();
         if (foldableCompanyNames != null) {
-            foldableCompanies = new ArrayList<>();
             for (String name : foldableCompanyNames.split(",")) {
                 company = cmgr.getPublicCompany(name);
                 if (company == null) company = cmgr.getPrivateCompany(name);

--- a/src/main/java/rails/game/action/LayBaseToken.java
+++ b/src/main/java/rails/game/action/LayBaseToken.java
@@ -142,9 +142,7 @@ public class LayBaseToken extends LayToken {
         if (asOption) return options;
 
         // check asAction attributes
-        return options
-                && Objects.equal(this.chosenStation, action.chosenStation)
-        ;
+        return options && Objects.equal(this.chosenStation, action.chosenStation);
     }
 
     @Override
@@ -163,22 +161,19 @@ public class LayBaseToken extends LayToken {
     }
 
     /** Deserialize */
-    private void readObject(ObjectInputStream in) throws IOException,
-    ClassNotFoundException {
-
+    private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
         in.defaultReadObject();
 
         MapManager mmgr = getRoot().getMapManager();
-        locations = new ArrayList<MapHex>();
         if (Util.hasValue(locationNames)) {
+            locations = new ArrayList<>();
             for (String hexName : locationNames.split(",")) {
                 locations.add(mmgr.getHex(hexName));
             }
         }
 
         if (specialPropertyId > 0) {
-            specialProperty =
-                (SpecialBaseTokenLay) SpecialProperty.getByUniqueId(getRoot(), specialPropertyId);
+            specialProperty = SpecialProperty.getByUniqueId(getRoot(), specialPropertyId);
         }
         if (chosenHexName != null && chosenHexName.length() > 0) {
             chosenHex = mmgr.getHex(chosenHexName);

--- a/src/main/java/rails/game/action/LayBonusToken.java
+++ b/src/main/java/rails/game/action/LayBonusToken.java
@@ -85,9 +85,8 @@ public class LayBonusToken extends LayToken {
         in.defaultReadObject();
 
         MapManager mmgr = getRoot().getMapManager();
-        // TODO: verify we should create this array (see issue found with LayBaseToken)
-        locations = new ArrayList<>();
         if (Util.hasValue(locationNames)) {
+            locations = new ArrayList<>();
             for (String hexName : locationNames.split(",")) {
                 locations.add(mmgr.getHex(hexName));
             }

--- a/src/main/java/rails/game/action/LayTile.java
+++ b/src/main/java/rails/game/action/LayTile.java
@@ -102,7 +102,7 @@ public class LayTile extends PossibleORAction implements Comparable<LayTile> {
             this.specialPropertyId = specialProperty.getUniqueId();
             Tile tile = specialProperty.getTile();
             if (tile != null) {
-                tiles = new ArrayList<Tile>();
+                tiles = new ArrayList<>();
                 tiles.add(tile);
             }
         }
@@ -324,9 +324,8 @@ public class LayTile extends PossibleORAction implements Comparable<LayTile> {
         MapManager mmgr = getRoot().getMapManager();
         TileManager tmgr = getRoot().getTileManager();
 
-        // TODO: verify we should create this array (see issue found with LayBaseToken)
-        locations = new ArrayList<>();
         if (Util.hasValue(locationNames)) {
+            locations = new ArrayList<>();
             for (String hexName : locationNames.split(",")) {
                 locations.add(mmgr.getHex(hexName));
             }

--- a/src/main/java/rails/game/action/LayToken.java
+++ b/src/main/java/rails/game/action/LayToken.java
@@ -20,7 +20,7 @@ public abstract class LayToken extends PossibleORAction {
     /*--- Preconditions ---*/
 
     /** Where to lay a token (null means anywhere) */
-    transient protected List<MapHex> locations = null;
+    transient protected List<MapHex> locations;
     protected String locationNames;
 
     /**
@@ -132,16 +132,13 @@ public abstract class LayToken extends PossibleORAction {
         // check asOption attributes
         LayToken action = (LayToken)pa;
         boolean options = (Objects.equal(this.locations, action.locations) || this.locations == null && action.locations.isEmpty())
-                && Objects.equal(this.specialProperty, action.specialProperty)
-        ;
+                && Objects.equal(this.specialProperty, action.specialProperty);
 
         // finish if asOptions check
         if (asOption) return options;
 
         // check asAction attributes
-        return options
-            && Objects.equal(this.chosenHex, action.chosenHex)
-        ;
+        return options && Objects.equal(this.chosenHex, action.chosenHex);
     }
 
     @Override

--- a/src/main/java/rails/game/action/MergeCompanies.java
+++ b/src/main/java/rails/game/action/MergeCompanies.java
@@ -4,7 +4,10 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+
+import org.jetbrains.annotations.NotNull;
 
 import com.google.common.base.Objects;
 
@@ -38,14 +41,13 @@ public class MergeCompanies extends PossibleAction {
     /**
      * Common constructor.
      */
-    public MergeCompanies(PublicCompany mergingCompany,
-            List<PublicCompany> targetCompanies, boolean forced) {
+    public MergeCompanies(PublicCompany mergingCompany, @NotNull List<PublicCompany> targetCompanies, boolean forced) {
         super(mergingCompany.getRoot()); // not defined by an activity yet
         this.mergingCompany = mergingCompany;
         this.mergingCompanyName = mergingCompany.getId();
         this.targetCompanies = targetCompanies;
         StringBuilder b = new StringBuilder();
-        canReplaceToken = new ArrayList<Boolean>(targetCompanies.size());
+        canReplaceToken = new ArrayList<>(targetCompanies.size());
         for (PublicCompany target : targetCompanies) {
             if (b.length() > 0) b.append(",");
             if (target == null) {
@@ -66,7 +68,7 @@ public class MergeCompanies extends PossibleAction {
 
     public MergeCompanies(PublicCompany mergingCompany,
             PublicCompany targetCompany, boolean forced) {
-        this (mergingCompany, Arrays.asList(targetCompany), forced);
+        this (mergingCompany, Collections.singletonList(targetCompany), forced);
     }
 
     /** Required for deserialization */
@@ -115,8 +117,7 @@ public class MergeCompanies extends PossibleAction {
         MergeCompanies action = (MergeCompanies)pa;
         boolean options = Objects.equal(this.mergingCompany, action.mergingCompany)
                 && Objects.equal(this.targetCompanies, action.targetCompanies)
-                && Objects.equal(this.canReplaceToken, action.canReplaceToken)
-        ;
+                && Objects.equal(this.canReplaceToken, action.canReplaceToken);
 
         // finish if asOptions check
         if (asOption) return options;
@@ -124,8 +125,7 @@ public class MergeCompanies extends PossibleAction {
         // check asAction attributes
         return options
                 && Objects.equal(this.selectedTargetCompany, action.selectedTargetCompany)
-                && Objects.equal(this.replaceToken, action.replaceToken)
-        ;
+                && Objects.equal(this.replaceToken, action.replaceToken);
     }
 
     @Override
@@ -154,7 +154,6 @@ public class MergeCompanies extends PossibleAction {
         CompanyManager cmgr = getCompanyManager();
         mergingCompany = cmgr.getPublicCompany(mergingCompanyName);
 
-        // TODO: verify we should create this array (see issue found with LayBaseToken)
         targetCompanies = new ArrayList<>();
         for (String name : targetCompanyNames.split(",")) {
             if (name.equals("null")) {

--- a/src/main/java/rails/game/action/NullAction.java
+++ b/src/main/java/rails/game/action/NullAction.java
@@ -67,6 +67,7 @@ public class NullAction extends PossibleAction {
 
    private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
        in.defaultReadObject();
+
        // required since Rails 2.0
        mode_enum = Mode.values()[mode];
    }

--- a/src/main/java/rails/game/action/ReachDestinations.java
+++ b/src/main/java/rails/game/action/ReachDestinations.java
@@ -5,6 +5,8 @@ import java.io.ObjectInputStream;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.jetbrains.annotations.NotNull;
+
 import com.google.common.base.Objects;
 
 import net.sf.rails.game.CompanyManager;
@@ -23,7 +25,7 @@ public class ReachDestinations extends PossibleORAction {
 
     // Server-side settings
     transient protected List<PublicCompany> possibleCompanies;
-    protected String possibleCompanyNames = "";
+    protected String possibleCompanyNames;
 
     // Client-side settings
     transient protected List<PublicCompany> reachedCompanies;
@@ -31,11 +33,11 @@ public class ReachDestinations extends PossibleORAction {
 
     public static final long serialVersionUID = 1L;
 
-    public ReachDestinations (RailsRoot root, List<PublicCompany> companies) {
+    public ReachDestinations (RailsRoot root, @NotNull List<PublicCompany> possibleCompanies) {
         super(root);
-        possibleCompanies = companies;
+        this.possibleCompanies = possibleCompanies;
         StringBuilder b = new StringBuilder();
-        for (PublicCompany company : companies) {
+        for (PublicCompany company : possibleCompanies) {
             if (b.length() > 0) b.append(",");
             b.append (company.getId());
         }
@@ -51,8 +53,6 @@ public class ReachDestinations extends PossibleORAction {
     }
 
     public void addReachedCompany (PublicCompany company) {
-        if (reachedCompanies == null)
-            reachedCompanies = new ArrayList<PublicCompany>();
         reachedCompanies.add (company);
         if (reachedCompanyNames.length() > 0) {
             reachedCompanyNames += ",";
@@ -88,18 +88,15 @@ public class ReachDestinations extends PossibleORAction {
                 RailsObjects.stringHelper(this)
                     .addToString("possibleCompanies", possibleCompanies)
                     .addToStringOnlyActed("reachedCompanies", reachedCompanies)
-                    .toString()
-        ;
+                    .toString();
     }
 
-    private void readObject(ObjectInputStream in) throws IOException,
-            ClassNotFoundException {
-
+    private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
         in.defaultReadObject();
 
         CompanyManager cmgr = getCompanyManager();
 
-        possibleCompanies = new ArrayList<PublicCompany>();
+        possibleCompanies = new ArrayList<>();
         if (Util.hasValue(possibleCompanyNames)) {
             for (String cname : possibleCompanyNames.split(",")) {
                 if (!"".equals(cname)) {
@@ -107,8 +104,9 @@ public class ReachDestinations extends PossibleORAction {
                 }
             }
         }
-        reachedCompanies = new ArrayList<PublicCompany>();
+
         if (Util.hasValue(reachedCompanyNames)) {
+            reachedCompanies = new ArrayList<>();
             for (String cname : reachedCompanyNames.split(",")) {
                 if (!"".equals(cname)) {
                     reachedCompanies.add(cmgr.getPublicCompany(cname));

--- a/src/main/java/rails/game/correct/MapCorrectionAction.java
+++ b/src/main/java/rails/game/correct/MapCorrectionAction.java
@@ -238,7 +238,7 @@ public class MapCorrectionAction extends CorrectionAction {
 
         TileManager tmgr = getRoot().getTileManager();
         if (sTileIds != null && sTileIds.length > 0) {
-            tiles = new ArrayList<Tile>();
+            tiles = new ArrayList<>();
             for ( String sTileId : sTileIds ) {
                 tiles.add(tmgr.getTile(sTileId));
             }
@@ -246,7 +246,7 @@ public class MapCorrectionAction extends CorrectionAction {
 
         // FIXME: Rewrite this with Rails1.x version flag
         if (tileIds != null && tileIds.length > 0) {
-            tiles = new ArrayList<Tile>();
+            tiles = new ArrayList<>();
             for ( int tileId : tileIds ) {
                 tiles.add(tmgr.getTile(String.valueOf(tileId)));
             }

--- a/src/main/java/rails/game/specific/_1835/FoldIntoPrussian.java
+++ b/src/main/java/rails/game/specific/_1835/FoldIntoPrussian.java
@@ -6,6 +6,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import org.jetbrains.annotations.NotNull;
+
 import net.sf.rails.game.RailsRoot;
 import rails.game.action.PossibleAction;
 import net.sf.rails.game.Company;
@@ -30,9 +32,9 @@ public class FoldIntoPrussian extends PossibleAction {
 
     public static final long serialVersionUID = 1L;
 
-    public FoldIntoPrussian(RailsRoot root, List<Company> companies) {
+    public FoldIntoPrussian(RailsRoot root, @NotNull List<Company> foldableCompanies) {
         super(root); // not defined by an activity yet
-        this.foldableCompanies = companies;
+        this.foldableCompanies = foldableCompanies;
         foldableCompanyNames = Util.joinNamesWithDelimiter(foldableCompanies, ",");
     }
 
@@ -45,11 +47,10 @@ public class FoldIntoPrussian extends PossibleAction {
     }
 
 
-    public void setFoldedCompanies(List<Company> foldedCompanies) {
+    public void setFoldedCompanies(@NotNull List<Company> foldedCompanies) {
         this.foldedCompanies = foldedCompanies;
         foldedCompanyNames = Util.joinNamesWithDelimiter (foldedCompanies, ",");
     }
-
 
     public List<Company> getFoldableCompanies() {
         return foldableCompanies;
@@ -111,8 +112,9 @@ public class FoldIntoPrussian extends PossibleAction {
 
         Company company;
         CompanyManager cmgr = getCompanyManager();
+
+        foldableCompanies = new ArrayList<>();
         if (foldableCompanyNames != null) {
-            foldableCompanies = new ArrayList<>();
             for (String name : foldableCompanyNames.split(",")) {
                 company = cmgr.getPublicCompany(name);
                 if (company == null) company = cmgr.getPrivateCompany(name);

--- a/src/main/java/rails/game/specific/_18EU/StartCompany_18EU.java
+++ b/src/main/java/rails/game/specific/_18EU/StartCompany_18EU.java
@@ -49,7 +49,6 @@ public class StartCompany_18EU extends StartCompany {
     }
 
     public void setMinorsToMerge(List<PublicCompany> minors) {
-
         minorsToMerge = minors;
 
         if ( minorsToMerge != null ) {
@@ -59,6 +58,8 @@ public class StartCompany_18EU extends StartCompany {
                 b.append(minor.getId());
             }
             minorsToMergeNames = b.toString();
+        } else {
+            minorsToMergeNames = null;
         }
     }
 
@@ -72,6 +73,8 @@ public class StartCompany_18EU extends StartCompany {
                 b.append(station.getSpecificId());
             }
             availableHomeStationNames = b.toString();
+        } else {
+            availableHomeStationNames = null;
         }
     }
 


### PR DESCRIPTION
This PR addresses several issues (really the same type of issue) that can occur while use of auto-load/save. The issue is specifically due to how we construct an action internally which is then stored in the execution history vs how it is deserialized and then (reloaded and) compared against that action history. In several cases, even when replaying (and hence comparing) one's own actions, changes are found due to differences in (usually) "empty" objects such as an empty `List` or empty `Map` whereas the action, for game play purposes, is really the same. This mostly has to do with how and when we are constructing arrays, lists and maps but in theory could happen with other object types too. This PR only addresses cases there it is clear when & how an object is created (and hence its variables) vs when it is deserialized. It is likely there are additional scenarios out there not addressed by the PR.

Before this PR we were running into auto-load failures frequently (between every 10-20 turn changes); post this change we have not yet seen a single auto-load failure (several hundred turn changes). 

I will add my detailed notes I made while troubleshooting this in a comment below, keep in mind I was "talking to myself" as I made the notes and so may be only make sense to me... but also adding it here for future reference for myself :)