### PR TITLE
refactor stock chart window to embed JavaFX in Swing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -83,7 +83,7 @@ dependencies {
 
 javafx {
     version = '14'
-    modules = ['javafx.controls']
+    modules = ['javafx.controls', 'javafx.swing']
 }
 
 sourceCompatibility = JavaVersion.VERSION_11

--- a/src/main/java/net/sf/rails/ui/swing/GameUIManager.java
+++ b/src/main/java/net/sf/rails/ui/swing/GameUIManager.java
@@ -54,7 +54,6 @@ import net.sf.rails.game.financial.Bank;
 import net.sf.rails.game.financial.StockRound;
 import net.sf.rails.game.round.RoundFacade;
 import net.sf.rails.game.state.Observer;
-import net.sf.rails.javafx.windows.FXStockChartWindow;
 import net.sf.rails.sound.SoundManager;
 import net.sf.rails.ui.swing.elements.CheckBoxDialog;
 import net.sf.rails.ui.swing.elements.DialogOwner;
@@ -84,6 +83,9 @@ public class GameUIManager implements DialogOwner {
     private StartRoundWindow startRoundWindow;
 
     protected JDialog currentDialog = null;
+
+    protected StockChartWindow stockChartWindow;
+
     protected PossibleAction currentDialogAction = null;
 
     protected RailsRoot railsRoot;
@@ -284,7 +286,7 @@ public class GameUIManager implements DialogOwner {
 
     public void gameUIInit(boolean newGame) {
         splashWindow.notifyOfStep(SplashWindow.STEP_STOCK_CHART);
-        FXStockChartWindow.launch(this);
+        stockChartWindow = new StockChartWindow(this);
 
         splashWindow.notifyOfStep(SplashWindow.STEP_REPORT_WINDOW);
 
@@ -545,7 +547,7 @@ public class GameUIManager implements DialogOwner {
                 case STOCK_MARKET:
                     boolean stockChartVisibilityHint = hint.isVisible() || configuredStockChartVisibility;
                     if (stockChartVisibilityHint != previousStockChartVisibilityHint) {
-                        FXStockChartWindow.setVisible(stockChartVisibilityHint);
+                        stockChartWindow.setVisible(stockChartVisibilityHint);
                         previousStockChartVisibilityHint = stockChartVisibilityHint;
                     }
                     break;
@@ -588,7 +590,7 @@ public class GameUIManager implements DialogOwner {
         } else if (uiHints.getActivePanel() == GuiDef.Panel.STATUS || correctionOverride) {
             log.debug("Entering Stock Round UI type");
             activeWindow = statusWindow;
-            FXStockChartWindow.setVisible(true);
+            stockChartWindow.setVisible(true);
             setMeVisible(statusWindow, true);
             setMeToFront(statusWindow);
 

--- a/src/main/java/net/sf/rails/ui/swing/StatusWindow.java
+++ b/src/main/java/net/sf/rails/ui/swing/StatusWindow.java
@@ -31,7 +31,6 @@ import net.sf.rails.game.financial.ShareSellingRound;
 import net.sf.rails.game.financial.StockRound;
 import net.sf.rails.game.financial.TreasuryShareRound;
 import net.sf.rails.game.round.RoundFacade;
-import net.sf.rails.javafx.windows.FXStockChartWindow;
 import net.sf.rails.ui.swing.elements.ActionButton;
 import net.sf.rails.ui.swing.elements.ActionCheckBoxMenuItem;
 import net.sf.rails.ui.swing.elements.ActionMenuItem;
@@ -669,7 +668,7 @@ public class StatusWindow extends JFrame implements ActionListener, KeyListener,
             gameUIManager.reportWindow.scrollDown();
             return;
         } else if (command.equals(MARKET_CMD)) {
-            FXStockChartWindow.setVisible(((JMenuItem) actor.getSource()).isSelected());
+            gameUIManager.stockChartWindow.setVisible(((JMenuItem) actor.getSource()).isSelected());
         } else if (command.equals(MAP_CMD)) {
             gameUIManager.orWindow.setVisible(((JMenuItem) actor.getSource()).isSelected());
         } else if (command.equals(CONFIG_CMD)) {

--- a/src/main/java/net/sf/rails/ui/swing/StockChartWindow.java
+++ b/src/main/java/net/sf/rails/ui/swing/StockChartWindow.java
@@ -1,0 +1,48 @@
+package net.sf.rails.ui.swing;
+
+import java.awt.*;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+
+import javax.swing.*;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javafx.application.Platform;
+import javafx.embed.swing.JFXPanel;
+import javafx.scene.Scene;
+import net.sf.rails.javafx.stockchart.FXStockChart;
+
+/**
+ * Wrapper around the JavaFX version of the StockChartWindow
+ */
+public class StockChartWindow extends JFrame {
+
+    private static final Logger log = LoggerFactory.getLogger(StockChartWindow.class);
+
+    public StockChartWindow(GameUIManager gameUIManager) {
+        final JFXPanel fxPanel = new JFXPanel();
+        add(fxPanel);
+        setTitle("Rails: Stock Chart");
+        setPreferredSize(new Dimension(600, 400));
+        setVisible(true);
+        setDefaultCloseOperation(DO_NOTHING_ON_CLOSE);
+
+        final JFrame frame = this;
+        addWindowListener(new WindowAdapter() {
+            @Override
+            public void windowClosing(WindowEvent e) {
+                gameUIManager.uncheckMenuItemBox(StatusWindow.REPORT_CMD);
+                frame.dispose();
+            }
+        });
+
+        Platform.runLater(() -> {
+            Scene scene = new Scene(new FXStockChart(gameUIManager));
+            fxPanel.setScene(scene);
+            frame.pack();
+        });
+    }
+
+}


### PR DESCRIPTION
This PR refactors the current JavaFX based stock chart window to remove the JavaFX `Application` approach and instead use Oracle's recommended approach for embedding JavaFX into a Swing based application (see https://docs.oracle.com/javase/8/javafx/interoperability-tutorial/swing-fx-interoperability.htm). This also removes the singleton approach for the stock chart window.