### PR TITLE
Fix Issue#130 by adding specific implementation of executePresidentTransferAfterDump for 1835

### DIFF
--- a/src/main/java/net/sf/rails/game/specific/_1835/StockRound_1835.java
+++ b/src/main/java/net/sf/rails/game/specific/_1835/StockRound_1835.java
@@ -7,20 +7,17 @@ package net.sf.rails.game.specific._1835;
 import java.util.List;
 import java.util.Set;
 import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
 
-import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Sets;
-import com.google.common.collect.SortedMultiset;
-
+import net.sf.rails.game.financial.*;
+import net.sf.rails.game.model.CertificatesModel;
 import rails.game.action.BuyCertificate;
 import rails.game.action.NullAction;
 import net.sf.rails.common.LocalText;
 import net.sf.rails.common.ReportBuffer;
 import net.sf.rails.game.*;
-import net.sf.rails.game.financial.PublicCertificate;
-import net.sf.rails.game.financial.StockRound;
-import net.sf.rails.game.financial.StockSpace;
-import net.sf.rails.game.financial.PlayerShareUtils;
 import net.sf.rails.game.model.PortfolioModel;
 import net.sf.rails.game.state.Portfolio;
 
@@ -278,5 +275,43 @@ public class StockRound_1835 extends StockRound {
 			super.setPriority(string);
 		}
 	}
-     
+
+
+    @Override
+    protected void executeShareTransfer(PublicCompany company, List<PublicCertificate> certsToSell, Player dumpedPlayer, int presSharesToSell) {
+
+        BankPortfolio bankTo = (BankPortfolio) pool.getParent();
+
+        if (dumpedPlayer != null && presSharesToSell > 0) {
+            executePresidentTransferAfterDump(company, new TreeSet<>(certsToSell), dumpedPlayer, presSharesToSell, company.getPresident(), bankTo);
+
+            ReportBuffer.add(this, LocalText.getText("IS_NOW_PRES_OF",
+                    dumpedPlayer.getId(),
+                    company.getId()));
+
+        }
+
+        // Transfer the sold certificates
+        Portfolio.moveAll(certsToSell, bankTo);
+    }
+
+    private void executePresidentTransferAfterDump(PublicCompany company, Set<PublicCertificate> certsToSell, Player newPresident, int presSharesToSell, Player oldPresident, BankPortfolio bankTo) {
+        PublicCertificate presidentCert = company.getPresidentsShare();
+
+        SortedSet<PublicCertificate.Combination> newPresidentsReplacementForPresidentShare = CertificatesModel.certificateCombinations(
+                newPresident.getPortfolioModel().getCertificates(company), presidentCert.getShares());
+
+        // FIXME: This should be based on a selection of the old president, however it chooses the combination with least certificates, which is favorable in most cases
+        PublicCertificate.Combination swapToOldPresident = newPresidentsReplacementForPresidentShare.first();
+
+        Portfolio.moveAll(swapToOldPresident, oldPresident);
+        presidentCert.moveTo(newPresident);
+
+        Set<PublicCertificate> oldPresidentsCertsWithoutCertsToSell = Sets.difference(oldPresident.getPortfolioModel().getCertificates(company), certsToSell);
+        SortedSet<PublicCertificate.Combination> sellableCertificateCombinations = CertificatesModel.certificateCombinations(
+                oldPresidentsCertsWithoutCertsToSell,
+                presSharesToSell);
+
+        Portfolio.moveAll(sellableCertificateCombinations.last(), bankTo);
+    }
 }


### PR DESCRIPTION
https://github.com/Rails-18xx/Rails/issues/130

We're not 100% sure about the line
`Portfolio.moveAll(sellableCertificateCombinations.last(), bankTo);`
We have tested it with all kinds of companies (1x 20, 2x20, 3x20 and the Prussian) in 1835 though and all worked as expected. 

Also, we did not incorporate this solution with the code in `PlayerShareUtils` since we do not know the specific needs of 1880, which uses this function as well. Maybe you can give us some insight on how we can share more code between the games for this issue. We made a method for this, since there is no need for the share swap to include the bank at all in 1835.