### PR TITLE
Load game replacing current game

### DIFF
--- a/src/main/java/net/sf/rails/common/ConfigManager.java
+++ b/src/main/java/net/sf/rails/common/ConfigManager.java
@@ -207,6 +207,10 @@ public class ConfigManager implements Configurable {
         transientConfig.put(key, value);
     }
 
+    public void clearTransientConfig() {
+        transientConfig.clear();
+    }
+
     public String getActiveProfile() {
         return activeProfile.getName();
     }

--- a/src/main/java/net/sf/rails/game/OpenGamesManager.java
+++ b/src/main/java/net/sf/rails/game/OpenGamesManager.java
@@ -1,0 +1,36 @@
+package net.sf.rails.game;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import net.sf.rails.ui.swing.GameUIManager;
+
+public class OpenGamesManager {
+
+    private static final OpenGamesManager instance = new OpenGamesManager();
+
+    private final Map<String, GameUIManager> openGames = new HashMap<>();
+    private OpenGamesManager() { }
+
+    public static OpenGamesManager getInstance() {
+        return instance;
+    }
+
+    public GameUIManager getGame(String id) {
+        return openGames.get(id);
+    }
+
+    public void addGame(GameUIManager gammeUIManager) {
+        // TODO: fix key
+        openGames.put(gammeUIManager.getRoot().getId(), gammeUIManager);
+    }
+
+    public void removeGame(GameUIManager gameUIManager) {
+        openGames.remove(gameUIManager.getRoot().getId());
+    }
+
+    public int countOfOpenGames() {
+        return openGames.size();
+    }
+
+}

--- a/src/main/java/net/sf/rails/ui/swing/AutoLoadPoller.java
+++ b/src/main/java/net/sf/rails/ui/swing/AutoLoadPoller.java
@@ -23,6 +23,8 @@ public class AutoLoadPoller extends Thread {
 
     private boolean pollingActive = false;
 
+    private boolean doPolling = true;
+
     private final String lastSavedFilenameFilepath;
     private String lastSavedFilename;
 
@@ -55,7 +57,7 @@ public class AutoLoadPoller extends Thread {
         int currentPollInterval = 1;
         int secs, sleepTime;
 
-        while ( true ) {
+        while ( doPolling ) {
             secs = Calendar.getInstance().get(Calendar.SECOND);
             try {
                 sleepTime = 1000 * (currentPollInterval - secs%currentPollInterval);
@@ -107,7 +109,6 @@ public class AutoLoadPoller extends Thread {
             }
             currentPollInterval = pollingInterval;
         }
-        // This thread never exits
     }
 
     public String getSaveDirectory() {
@@ -167,5 +168,8 @@ public class AutoLoadPoller extends Thread {
         this.lastSavedFilename = lastSavedFilename;
     }
 
+    public void close() {
+        doPolling = false;
+    }
 
 }

--- a/src/main/java/net/sf/rails/ui/swing/GameSetupWindow.java
+++ b/src/main/java/net/sf/rails/ui/swing/GameSetupWindow.java
@@ -1,11 +1,21 @@
 package net.sf.rails.ui.swing;
 
 import java.awt.*;
-import java.awt.event.*;
-import java.util.*;
+import java.awt.event.ItemEvent;
+import java.awt.event.ItemListener;
+import java.awt.event.KeyEvent;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.util.Arrays;
+import java.util.LinkedList;
 import java.util.List;
+import java.util.SortedMap;
 
 import javax.swing.*;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 
 import net.sf.rails.common.Config;
 import net.sf.rails.common.ConfigManager;
@@ -13,10 +23,6 @@ import net.sf.rails.common.GameInfo;
 import net.sf.rails.common.GameOption;
 import net.sf.rails.common.GameOptionsSet;
 import net.sf.rails.common.LocalText;
-
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 
 
 /**
@@ -66,7 +72,7 @@ public class GameSetupWindow extends JDialog {
         initPlayersPane(selectedGame);
         initConfigBox();
         this.pack();
-        this.setVisible(true);
+        this.setVisible(false);
     }
 
     private void initialize() {

--- a/src/main/java/net/sf/rails/ui/swing/GameUIManager.java
+++ b/src/main/java/net/sf/rails/ui/swing/GameUIManager.java
@@ -33,6 +33,7 @@ import ch.qos.logback.classic.PatternLayout;
 import ch.qos.logback.classic.spi.LoggingEvent;
 import ch.qos.logback.core.read.CyclicBufferAppender;
 import net.sf.rails.common.Config;
+import net.sf.rails.common.ConfigManager;
 import net.sf.rails.common.DisplayBuffer;
 import net.sf.rails.common.GuiDef;
 import net.sf.rails.common.GuiHints;
@@ -41,6 +42,7 @@ import net.sf.rails.common.notify.Discord;
 import net.sf.rails.common.notify.Slack;
 import net.sf.rails.game.GameManager;
 import net.sf.rails.game.MapHex;
+import net.sf.rails.game.OpenGamesManager;
 import net.sf.rails.game.OperatingRound;
 import net.sf.rails.game.Phase;
 import net.sf.rails.game.Player;
@@ -190,6 +192,8 @@ public class GameUIManager implements DialogOwner {
             myTurn = getCurrentPlayer().getId().equals(localPlayerName);
             log.debug("starting game with my turn: {}", myTurn);
         }
+
+        OpenGamesManager.getInstance().addGame(this);
     }
 
     private void initWindowSettings() {
@@ -204,6 +208,40 @@ public class GameUIManager implements DialogOwner {
         }
         return JOptionPane.showConfirmDialog(parent, LocalText.getText("CLOSE_WINDOW"),
                 LocalText.getText("Select"), JOptionPane.OK_CANCEL_OPTION) == JOptionPane.OK_OPTION;
+    }
+
+    public void closeGame() {
+        if ( myTurn ) {
+            // TODO: confirm game close if in turn?
+        }
+        OpenGamesManager.getInstance().removeGame(this);
+        getWindowSettings().save();
+        if ( startRoundWindow != null ) {
+            startRoundWindow.dispose();
+        }
+        if ( statusWindow != null ) {
+            statusWindow.dispose();
+        }
+        if ( reportWindow != null ) {
+            reportWindow.dispose();
+        }
+        if ( orWindow != null ) {
+            orWindow.dispose();
+        }
+        if ( configWindow != null ) {
+            configWindow.dispose();
+        }
+        if ( currentDialog != null ) {
+            currentDialog.dispose();
+        }
+        if ( autoLoadPoller != null ) {
+            autoLoadPoller.setActive(false);
+            autoLoadPoller.close();
+        }
+        // TODO: terminate things like Discord
+
+        // clean up config items that are game play specific (ie like Discord)
+        ConfigManager.getInstance().clearTransientConfig();
     }
 
     public void terminate() {

--- a/src/main/java/net/sf/rails/util/RunGame.java
+++ b/src/main/java/net/sf/rails/util/RunGame.java
@@ -1,17 +1,14 @@
 package net.sf.rails.util;
 
 import java.awt.*;
-import java.awt.desktop.OpenFilesEvent;
-import java.awt.desktop.OpenFilesHandler;
 import java.io.File;
-
-import javax.swing.*;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import net.sf.rails.common.ConfigManager;
-import net.sf.rails.ui.swing.AutoSaveLoadDialog;
+import net.sf.rails.game.OpenGamesManager;
 import net.sf.rails.ui.swing.GameSetupController;
 
 public class RunGame {
@@ -19,36 +16,65 @@ public class RunGame {
     private static final Logger log = LoggerFactory.getLogger(RunGame.class);
 
     public static void main(String[] args) {
-        final String[] fileName = { null };
+        String fileName = null;
+        AtomicBoolean hasStarted = new AtomicBoolean(false);
 
         if (args != null && args.length > 0) {
             for (String arg : args) {
-                System.out.println ("Arg: "+arg);
+                log.debug("found arg: {}", arg);
             }
-            fileName[0] = args[0];
+            fileName = args[0];
         }
+
+        // Initialize configuration
+        ConfigManager.initConfiguration(false);
 
         if ( Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported(Desktop.Action.APP_OPEN_FILE)) {
             Desktop.getDesktop().setOpenFileHandler(e -> {
                 for ( File file : e.getFiles() ) {
                     // open the file
-                    fileName[0] = file.toString();
+                    log.debug("received file open event for: {}", file);
+
+                    if ( OpenGamesManager.getInstance().countOfOpenGames() > 0 ) {
+                        // unable to currently open more than one game
+                        log.warn("Unable to open more than one game");
+                        break;
+                    }
+                    synchronized (hasStarted) {
+                        if ( hasStarted.get() ) {
+                            log.debug("hiding game setup controller");
+                            GameSetupController.getInstance().prepareGameUIInit();
+                        } else {
+                            hasStarted.set(true);
+                        }
+                        log.debug("starting passed in game from: {}", file);
+                        new Thread(() -> GameLoader.loadAndStartGame(file)).start();
+                    }
                     // break out as we only handle one game at a time...
                     break;
                 }
             });
         }
 
-        // Initialize configuration
-        ConfigManager.initConfiguration(false);
-
-        // currently we only start one game
-        if ( fileName[0] != null ) {
-            GameLoader.loadAndStartGame(new File(fileName[0]));
-        } else {
-            /* Start the rails.game selector, which will do all the rest. */
-            GameSetupController.Builder setupBuilder = GameSetupController.builder();
-            setupBuilder.start();
+        try {
+            // sleep for a tad to allow for any open file events to come through before we
+            // display the setup controller otherwise it can display briefly and then is hidden
+            Thread.sleep(200);
+        }
+        catch (InterruptedException e) {
+            // ignored
+        }
+        synchronized (hasStarted) {
+            if ( ! hasStarted.get() ) {
+                if ( fileName != null ) {
+                    GameLoader.loadAndStartGame(new File(fileName));
+                } else {
+                    /* Start the rails.game selector, which will do all the rest. */
+                    log.debug("starting game setup controller");
+                    GameSetupController.getInstance().show();
+                }
+                hasStarted.set(true);
+            }
         }
     }
 }

--- a/src/main/java/rails/game/action/GameAction.java
+++ b/src/main/java/rails/game/action/GameAction.java
@@ -15,7 +15,7 @@ public class GameAction extends PossibleAction {
 
     private static final long serialVersionUID = 1L;
 
-    public static enum Mode { SAVE, LOAD, UNDO, FORCED_UNDO, REDO, EXPORT, RELOAD }
+    public static enum Mode { SAVE, LOAD, UNDO, FORCED_UNDO, REDO, EXPORT, RELOAD, NEW }
 
     // Server-side settings
     protected Mode mode = null;


### PR DESCRIPTION
This PR adds support to load a new game (not reload/autoload) but a completely new game replacing the currently open game.

On a Mac you can't (easily for an end user) open multiple copies of the Rails app if you are playing multiple games in real-time so this adds support so you can at least easily switch between them without having to quit and restart the app as currently is required. Obviously is also useful on other platforms too