### PR TITLE
no network window config & close windows

### DIFF
--- a/src/main/java/net/sf/rails/algorithms/NetworkGraph.java
+++ b/src/main/java/net/sf/rails/algorithms/NetworkGraph.java
@@ -395,7 +395,7 @@ public class NetworkGraph {
         return vertexes;
     }
 
-    public void visualize(String title) {
+    public JFrame visualize(String title) {
         // show network mapGraph
         if (graph.vertexSet().size() > 0) {
             JGraphXAdapter<NetworkVertex, NetworkEdge> jGraphXAdapter = new JGraphXAdapter<>(graph);
@@ -415,7 +415,9 @@ public class NetworkGraph {
             frame.getContentPane().add(new JScrollPane(graphComponent));
             frame.pack();
             frame.setVisible(true);
+            return frame;
         }
+        return null;
     }
 
     /**

--- a/src/main/java/net/sf/rails/ui/swing/GameUIManager.java
+++ b/src/main/java/net/sf/rails/ui/swing/GameUIManager.java
@@ -217,7 +217,7 @@ public class GameUIManager implements DialogOwner {
         OpenGamesManager.getInstance().removeGame(this);
         getWindowSettings().save();
         if ( startRoundWindow != null ) {
-            startRoundWindow.dispose();
+            startRoundWindow.close();
         }
         if ( statusWindow != null ) {
             statusWindow.dispose();

--- a/src/main/java/net/sf/rails/ui/swing/ORWindow.java
+++ b/src/main/java/net/sf/rails/ui/swing/ORWindow.java
@@ -141,7 +141,6 @@ public class ORWindow extends DockingFrame implements ActionPerformer {
         log.debug("OrWindow size = {}", this.getSize());
 
         final JFrame frame = this;
-        final GameUIManager guiMgr = gameUIManager;
         addWindowListener(new WindowAdapter() {
             @Override
             public void windowClosing(WindowEvent e) {
@@ -153,15 +152,20 @@ public class ORWindow extends DockingFrame implements ActionPerformer {
                     setVisible(false);
                 }
             }
+
+            @Override
+            public void windowClosed(WindowEvent e) {
+                orPanel.dispose();
+            }
         });
         addComponentListener(new ComponentAdapter() {
             @Override
             public void componentMoved(ComponentEvent e) {
-                guiMgr.getWindowSettings().set(frame);
+                gameUIManager.getWindowSettings().set(frame);
             }
             @Override
             public void componentResized(ComponentEvent e) {
-                guiMgr.getWindowSettings().set(frame);
+                gameUIManager.getWindowSettings().set(frame);
             }
         });
 

--- a/src/main/resources/LocalisedText.properties
+++ b/src/main/resources/LocalisedText.properties
@@ -222,6 +222,7 @@ Config.label.map.displayCurrentRoutes=Display routes of active company
 Config.label.map.image.display=Display background map
 Config.label.map.highlightHexes=Highlight company locations 
 Config.label.map.zoomstep=Map zoomstep
+Config.label.map.route.window.display=Display network window on route calculation?
 Config.label.money_format=Money format
 Config.label.or.number_format=OR number format
 Config.label.or.window.dockablePanels=Flexible panels for operating round

--- a/src/main/resources/data/Properties.xml
+++ b/src/main/resources/data/Properties.xml
@@ -48,6 +48,7 @@
 		<Property name="map.image.display" type="BOOLEAN" />
 		<Property name="map.displayCurrentRoutes" type="BOOLEAN" />
 		<Property name="map.highlightHexes" type="BOOLEAN" />
+        <Property name="map.route.window.display" type="BOOLEAN" />
 	</Section>
 	<Section name="Windows">
 		<Property name="report.window.type" type="LIST" values="static,dynamic" />


### PR DESCRIPTION
Added a configuration option to _not_ display the route (ie network graph) window when you click on the company name to calculate possible revenue.

Also added tracking of the route windows that are opened so we can close them when we load a new game 