### PR TITLE
Add DCO & MAINTAINERS, touch up README

### DIFF
--- a/DCO
+++ b/DCO
@@ -1,0 +1,37 @@
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+1 Letterman Drive
+Suite D4700
+San Francisco, CA, 94129
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -3,7 +3,7 @@ BCRodich <RodichBruce@gmail.com>
 Bill Rosgen <rosgen@gmail.com>
 Brett Lentz <blentz@users.noreply.github.com>
 Chris Noon <chrisnoo@msn.com>
-Dr. Martin Brumm <neutronc@users.noreply.github.com>
+Dr. Martin Brumm <dr.martin.brumm@googlemail.com>
 Erik Vos <erik.vos@xs4all.nl>
 Frederick Weld <frederick.weld@gmail.com>
 Freek Dijkstra <macfreek@users.sourceforge.net>

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,0 +1,22 @@
+Adam Badura <abadura@o2.pl>
+BCRodich <RodichBruce@gmail.com>
+Bill Rosgen <rosgen@gmail.com>
+Brett Lentz <blentz@users.noreply.github.com>
+Chris Noon <chrisnoo@msn.com>
+Dr. Martin Brumm <neutronc@users.noreply.github.com>
+Erik Vos <erik.vos@xs4all.nl>
+Frederick Weld <frederick.weld@gmail.com>
+Freek Dijkstra <macfreek@users.sourceforge.net>
+Jason Klapste <jklapste@gmail.com>
+Jungy <jungorend@gmail.com>
+Larry North <lnorth@swnorth.com>
+Marc Arndt <marc.arndt@masimi.de>
+Marek Jeszka <marek.jeszka@gmail.com>
+Mark J. Smith <krazick@users.sourceforge.net>
+Michael Alexander <outsidepasser@gmail.com>
+Michal Bazynski <bazik@bazikapps.pl>
+Stefan Frey <stefan.frey@web.de>
+Sven Erik Knop <seknop@gmail.com>
+frederickweld <frederick.weld@gmail.com>
+jklap <jklapste@gmail.com>
+madoar <madoar@users.noreply.github.com>

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Rails
 
 Rails: an 18xx game system.
-Copyright (C) 2005 Brett Lentz
+Copyright (C) 2005 [Brett Lentz and other contributors](MAINTAINERS)
 
-A Java playing aid for playing 18xx based games via email or in Hotseat mode.
+A Java playing aid for playing 18xx based games.
 
 This program is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License
@@ -18,3 +18,11 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+
+# Certificate of Origin
+
+By contributing to this project you agree to the Developer Certificate of
+Origin (DCO). This document was created by the Linux Kernel community and is a
+simple statement that you, as a contributor, have the legal right to make the
+contribution. See the [DCO](DCO) file for details.
+


### PR DESCRIPTION
This PR adds a Developer Certificate of Origin. This is a simple statement that contributors are making contributions that are their own code.

I've also added a MAINTAINERS file that I generated with `git shortlog`. This file documents the folks who have contributed to the project over the years. If there's anything that we need to do around copyright or licensing, these are the folks who have contributed to the code and retain ownership over how their contributions are used.

I don't expect this to change how we work. This is just taking something that has been implicit for a very long time and making it explicit.