### PR TITLE
Move companies field to subclasses

### DIFF
--- a/src/main/java/net/sf/rails/ui/swing/GameStatus.java
+++ b/src/main/java/net/sf/rails/ui/swing/GameStatus.java
@@ -143,6 +143,9 @@ public class GameStatus extends GridPanel implements ActionListener {
     // Company (from treasury): -1.
     protected int actorIndex = -2;
 
+    private int nc;
+    private PublicCompany[] companies;
+
     protected final ButtonGroup buySellGroup = new ButtonGroup();
     protected ClickField dummyButton; // To be selected if none else is.
 

--- a/src/main/java/net/sf/rails/ui/swing/GridPanel.java
+++ b/src/main/java/net/sf/rails/ui/swing/GridPanel.java
@@ -64,8 +64,6 @@ implements ActionListener, KeyListener {
     protected static Color buttonHighlight = new Color(255, 160, 80);
 
     protected PlayerManager players;
-    protected int nc;
-    protected PublicCompany[] companies;
     protected RoundFacade round;
     protected PublicCompany c;
     protected JComponent f;

--- a/src/main/java/net/sf/rails/ui/swing/ORPanel.java
+++ b/src/main/java/net/sf/rails/ui/swing/ORPanel.java
@@ -121,8 +121,10 @@ implements ActionListener, KeyListener, RevenueListener {
     private ActionButton redoButton;
 
     // Current state
-    private int playerIndex = -1;
     private int orCompIndex = -1;
+
+    private int nc;
+    private PublicCompany[] companies;
 
     private PublicCompany orComp = null;
 
@@ -1413,18 +1415,6 @@ implements ActionListener, KeyListener, RevenueListener {
         button1.setEnabled(false);
 
         orUIManager.getMap().setTrainPaths(null);
-    }
-
-    // TEMPORARY
-    public PublicCompany getORComp() {
-        return orComp;
-    }
-
-    public String getORPlayer() {
-        if (playerIndex >= 0)
-            return players.getPlayerByPosition(playerIndex).getId();
-        else
-            return "";
     }
 
     private void setSelect(JComponent f, JComponent s, boolean active) {

--- a/src/main/java/net/sf/rails/ui/swing/ORWindow.java
+++ b/src/main/java/net/sf/rails/ui/swing/ORWindow.java
@@ -222,15 +222,8 @@ public class ORWindow extends DockingFrame implements ActionPerformer {
 
     @Override
     public boolean process(PossibleAction action) {
-
-        // Add the actor for safety checking in the server
-        if (action != null) action.setPlayerName(orPanel.getORPlayer());
         // Process the action
-        boolean result = gameUIManager.processAction(action);
-        // Display any error message
-        //displayServerMessage();
-
-        return result;
+        return gameUIManager.processAction(action);
     }
 
     // Not yet used


### PR DESCRIPTION
This PR moves both the `companies` and `nc` fields from `GridPanel` to its subclasses.
The reason for this change is that both subclasses use different sources to fill the `companies` array.
In a later PR I want to change the `companies` array to the used source, so that we can remove the intermediary.

In addition I've removed the `playerIndex` field in `ORPanel`. The reason for this change is that the `playerIndex` field is never changed.