### PR TITLE
Pr mbr/abstracting special tile lay

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,0 +1,50 @@
+# Rails-18xx 2.2 Release
+This release is meant to show the current state of the Rails-18xx implementation.
+
+Due to different reasons Rails-18xx 2.0 and 2.1 have not been release as production releases. We hope that the audience finds the release usefull.
+As usual we welcome bug reports and  save games that show the affected states of the game.
+
+We would like to **thank** the varios bug reporters and the developers who have contributed over the years for one feature or ground breaking work.
+
+
+## New Features
+
+* Notification of Moves via Slack
+* Notification of Moves via Discord
+* Autoloading and Autopolling for near time gaming allowing you to reload the save game that has changed during turns
+* Direct Revenue Allocation for various Contracts possible
+   * State of Direct Revenue Allocation is static towards company operations budget (no Half pay) - Workaround you half the allocation and add the rest to normal revenue distribution
+ * Installers for Windows, Mac OS, Linux (Redhat)
+
+## New games
+We continue on expanding the game base, the first new game on this for this release is 18Chesapeake.
+
+## Status of Games
+* Implementation of 18Chesapeake started, needs playtesting, bug reports welcome
+* Implementation of 1837 - Have a look but be prepared that it might break... 
+   * Open Topics in 1837 Implementation:
+     * Revenue Calculation of Coal Trains
+     * Coal Minors merging round implementation not always working as intended..
+
+## Bug Fixes
+* 1835 : 
+  * Numerous Fixes in regard to the director shares (you cant split sell them in 1835)
+  * Fixes for the Forced Sale of Shares 
+* 1856:
+  * Fix multiple Rights issue upon foundation of the CGR
+
+## Issues fixed:
+ * #55
+ * #205 
+ * #180
+ * #179
+ * #129 
+ * #130 
+ * #75 
+ * #71 
+ * #72 
+ * #73
+ * #76 
+ * #77 
+ * #78 
+ * #90 

--- a/src/main/java/net/sf/rails/game/OperatingRound.java
+++ b/src/main/java/net/sf/rails/game/OperatingRound.java
@@ -1800,6 +1800,12 @@ public class OperatingRound extends Round implements Observer {
                 if (validateSpecialTileLay(layTile))
                     currentSpecialTileLays.add(layTile);
             }
+              for (SpecialMultiTileLay smtl : getSpecialProperties(SpecialMultiTileLay.class)) {
+
+                LayTile layTile = new LayTile(smtl);
+                if (validateSpecialTileLay(layTile))
+                    currentSpecialTileLays.add(layTile);
+            }
         }
 
         if (display) {

--- a/src/main/java/net/sf/rails/game/OperatingRound.java
+++ b/src/main/java/net/sf/rails/game/OperatingRound.java
@@ -1800,12 +1800,12 @@ public class OperatingRound extends Round implements Observer {
                 if (validateSpecialTileLay(layTile))
                     currentSpecialTileLays.add(layTile);
             }
-              for (SpecialMultiTileLay smtl : getSpecialProperties(SpecialMultiTileLay.class)) {
+/*              for (SpecialMultiTileLay smtl : getSpecialProperties(SpecialMultiTileLay.class)) {
 
                 LayTile layTile = new LayTile(smtl);
                 if (validateSpecialTileLay(layTile))
                     currentSpecialTileLays.add(layTile);
-            }
+            }*/
         }
 
         if (display) {

--- a/src/main/java/net/sf/rails/game/special/SpecialSingleTileLay.java
+++ b/src/main/java/net/sf/rails/game/special/SpecialSingleTileLay.java
@@ -1,0 +1,114 @@
+package net.sf.rails.game.special;
+
+import net.sf.rails.common.LocalText;
+import net.sf.rails.common.parser.ConfigurationException;
+import net.sf.rails.common.parser.Tag;
+import net.sf.rails.game.*;
+import net.sf.rails.util.Util;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class SpecialSingleTileLay extends SpecialTileLay {
+    /**
+     * Used by Configure (via reflection) only
+     *
+     * @param parent Railsitem this belongs
+     * @param id this Item has
+     */
+    public SpecialSingleTileLay(RailsItem parent, String id) {
+        super(parent, id);
+    }
+
+    @Override
+    public void configureFromXML(Tag tag) throws ConfigurationException {
+        super.configureFromXML(tag);
+
+        Tag tileLayTag = tag.getChild("SpecialSingleTileLay");
+        if (tileLayTag == null) {
+            throw new ConfigurationException("<SpecialSingleTileLay> tag missing");
+        }
+
+        locationCodes = tileLayTag.getAttributeAsString("location");
+        if (!Util.hasValue(locationCodes))
+            throw new ConfigurationException("SpecialSingleTileLay: location missing");
+
+        tileId = tileLayTag.getAttributeAsString("tile", null);
+
+        String coloursString = tileLayTag.getAttributeAsString("colour");
+        if (Util.hasValue(coloursString)) {
+            tileColours = coloursString.split(",");
+        }
+
+        name = tileLayTag.getAttributeAsString("name");
+
+        extra = tileLayTag.getAttributeAsBoolean("extra", extra);
+        free = tileLayTag.getAttributeAsBoolean("free", free);
+        connected = tileLayTag.getAttributeAsBoolean("connected", connected);
+        discount = tileLayTag.getAttributeAsInteger("discount", discount);
+
+        if (tileId != null) {
+            description = LocalText.getText("LayNamedTileInfo",
+                    tileId,
+                    name != null ? name : "",
+                            locationCodes,
+                            (extra ? LocalText.getText("extra"):LocalText.getText("notExtra")),
+                            (free ? LocalText.getText("noCost") : discount != 0 ? LocalText.getText("discount", discount) :
+                                LocalText.getText("normalCost")),
+                            (connected ? LocalText.getText("connected") : LocalText.getText("unconnected"))
+            );
+        } else {
+            description = LocalText.getText("LayTileInfo",
+                    locationCodes,
+                    (tileColours != null ? Arrays.toString(tileColours).replaceAll("[\\[\\]]", ""): ""),
+                    (extra ? LocalText.getText("extra"):LocalText.getText("notExtra")),
+                    (free ? LocalText.getText("noCost") : discount != 0 ? LocalText.getText("discount", discount) :
+                        LocalText.getText("normalCost")),
+                    (connected ? LocalText.getText("connected") : LocalText.getText("unconnected"))
+            );
+        }
+
+    }
+
+    @Override
+	public void finishConfiguration (RailsRoot root)
+    throws ConfigurationException {
+
+        TileManager tmgr = root.getTileManager();
+        MapManager mmgr = root.getMapManager();
+        MapHex hex;
+
+        if (tileId != null) {
+            tile = tmgr.getTile(tileId);
+        }
+
+        locations = new ArrayList<>();
+        for (String hexName : locationCodes.split(",")) {
+            hex = mmgr.getHex(hexName);
+            if (hex == null)
+                throw new ConfigurationException("Location " + hexName
+                        + " does not exist");
+            locations.add(hex);
+        }
+
+    }
+
+    @Override
+	public String toText() {
+        return "SpecialSingleTileLay comp=" + originalCompany.getId()
+        + " hex=" + locationCodes
+        + " colour="+Util.joinWithDelimiter(tileColours, ",")
+        + " extra=" + extra + " cost=" + free + " connected=" + connected;
+    }
+
+    @Override
+    public String toMenu() {
+        return description;
+    }
+
+    @Override
+    public String getInfo() {
+        return description;
+    }
+}

--- a/src/main/java/net/sf/rails/game/special/SpecialTileLay.java
+++ b/src/main/java/net/sf/rails/game/special/SpecialTileLay.java
@@ -11,17 +11,17 @@ import net.sf.rails.game.*;
 import net.sf.rails.util.Util;
 
 
-public class SpecialTileLay extends SpecialProperty {
+public abstract class SpecialTileLay extends SpecialProperty {
 
-    private String locationCodes = null;
-    private List<MapHex> locations = null;
-    private String tileId = null;
-    private Tile tile = null;
-    private String name = null;
-    private boolean extra = false;
-    private boolean free = false;
-    private int discount = 0;
-    private boolean connected = false;
+    protected String locationCodes = null;
+    protected List<MapHex> locations = null;
+    protected String tileId = null;
+    protected Tile tile = null;
+    protected String name = null;
+    protected boolean extra = false;
+    protected boolean free = false;
+    protected int discount = 0;
+    protected boolean connected = false;
     
     /** Tile colours that can be laid with this special property.
      * Default is same colours as is allowed in a a normal tile lay.
@@ -38,76 +38,13 @@ public class SpecialTileLay extends SpecialProperty {
     @Override
     public void configureFromXML(Tag tag) throws ConfigurationException {
         super.configureFromXML(tag);
-
-        Tag tileLayTag = tag.getChild("SpecialTileLay");
-        if (tileLayTag == null) {
-            throw new ConfigurationException("<SpecialTileLay> tag missing");
-        }
-
-        locationCodes = tileLayTag.getAttributeAsString("location");
-        if (!Util.hasValue(locationCodes))
-            throw new ConfigurationException("SpecialTileLay: location missing");
-
-        tileId = tileLayTag.getAttributeAsString("tile", null);
-
-        String coloursString = tileLayTag.getAttributeAsString("colour");
-        if (Util.hasValue(coloursString)) {
-            tileColours = coloursString.split(",");
-        }
-
-        name = tileLayTag.getAttributeAsString("name");
-
-        extra = tileLayTag.getAttributeAsBoolean("extra", extra);
-        free = tileLayTag.getAttributeAsBoolean("free", free);
-        connected = tileLayTag.getAttributeAsBoolean("connected", connected);
-        discount = tileLayTag.getAttributeAsInteger("discount", discount);
-
-        if (tileId != null) {
-            description = LocalText.getText("LayNamedTileInfo",
-                    tileId,
-                    name != null ? name : "",
-                            locationCodes,
-                            (extra ? LocalText.getText("extra"):LocalText.getText("notExtra")),
-                            (free ? LocalText.getText("noCost") : discount != 0 ? LocalText.getText("discount", discount) : 
-                                LocalText.getText("normalCost")),
-                            (connected ? LocalText.getText("connected") : LocalText.getText("unconnected"))
-            );
-        } else {
-            description = LocalText.getText("LayTileInfo",
-                    locationCodes,
-                    (tileColours != null ? Arrays.toString(tileColours).replaceAll("[\\[\\]]", ""): ""),
-                    (extra ? LocalText.getText("extra"):LocalText.getText("notExtra")),
-                    (free ? LocalText.getText("noCost") : discount != 0 ? LocalText.getText("discount", discount) : 
-                        LocalText.getText("normalCost")),
-                    (connected ? LocalText.getText("connected") : LocalText.getText("unconnected"))
-            );
-        }
-
     }
 
     @Override
-	public void finishConfiguration (RailsRoot root)
-    throws ConfigurationException {
+	public abstract void finishConfiguration(RailsRoot root)
+    throws ConfigurationException;
 
-        TileManager tmgr = root.getTileManager();
-        MapManager mmgr = root.getMapManager();
-        MapHex hex;
-
-        if (tileId != null) {
-            tile = tmgr.getTile(tileId);
-        }
-
-        locations = new ArrayList<MapHex>();
-        for (String hexName : locationCodes.split(",")) {
-            hex = mmgr.getHex(hexName);
-            if (hex == null)
-                throw new ConfigurationException("Location " + hexName
-                        + " does not exist");
-            locations.add(hex);
-        }
-
-    }
-
+    @Override
     public boolean isExecutionable() {
         return true;
     }
@@ -119,7 +56,7 @@ public class SpecialTileLay extends SpecialProperty {
     public boolean isFree() {
         return free;
     }
-    
+
     public int getDiscount() {
         return discount;
     }
@@ -149,20 +86,11 @@ public class SpecialTileLay extends SpecialProperty {
     }
 
     @Override
-	public String toText() {
-        return "SpecialTileLay comp=" + originalCompany.getId()
-        + " hex=" + locationCodes
-        + " colour="+Util.joinWithDelimiter(tileColours, ",")
-        + " extra=" + extra + " cost=" + free + " connected=" + connected;
-    }
+	public abstract String toText();
 
     @Override
-    public String toMenu() {
-        return description;
-    }
+    public abstract String toMenu();
 
     @Override
-    public String getInfo() {
-        return description;
-    }
+    public abstract String getInfo();
 }

--- a/src/main/resources/data/1830/CompanyManager.xml
+++ b/src/main/resources/data/1830/CompanyManager.xml
@@ -39,8 +39,8 @@
 			longname="Champlain &amp; St.Lawrence">
 		<Blocking hex="B20"/>
 		<SpecialProperties>
-			<SpecialProperty condition="ifOwnedByCompany" when="tileLayingStep" class="net.sf.rails.game.special.SpecialTileLay">
-				<SpecialTileLay colour="yellow" location="B20" extra="yes" free="yes"/>
+			<SpecialProperty condition="ifOwnedByCompany" when="tileLayingStep" class="net.sf.rails.game.special.SpecialSingleTileLay">
+				<SpecialSingleTileLay colour="yellow" location="B20" extra="yes" free="yes"/>
 			</SpecialProperty>
 		</SpecialProperties>
 	</Company>
@@ -48,8 +48,8 @@
 		longname="Delaware &amp; Hudson">
 		<Blocking hex="F16"/>
 		<SpecialProperties>
-			<SpecialProperty condition="ifOwnedByCompany" when="tileLayingStep" class="net.sf.rails.game.special.SpecialTileLay">
-				<SpecialTileLay location="F16" extra="no" free="no" tile="57" />
+			<SpecialProperty condition="ifOwnedByCompany" when="tileLayingStep" class="net.sf.rails.game.special.SpecialSingleTileLay">
+				<SpecialSingleTileLay location="F16" extra="no" free="no" tile="57" />
 			</SpecialProperty>
 			<SpecialProperty condition="ifOwnedByCompany" when="tokenLayingStep" class="net.sf.rails.game.special.SpecialBaseTokenLay">
 				<SpecialBaseTokenLay location="F16" extra="no" free="yes" requiresTile = "yes"/>

--- a/src/main/resources/data/1835/CompanyManager.xml
+++ b/src/main/resources/data/1835/CompanyManager.xml
@@ -52,11 +52,11 @@
 	</Company>
 	<Company name="OBB" longname="Ostbayerische Bahn" type="Private" basePrice="120" revenue="10">
 		<SpecialProperties>
-			<SpecialProperty condition="ifOwnedByPlayer" when="tileLayingStep" class="net.sf.rails.game.special.SpecialTileLay">
-				<SpecialTileLay location="M15" colour="yellow" extra="yes" free="yes" />
+			<SpecialProperty condition="ifOwnedByPlayer" when="tileLayingStep" class="net.sf.rails.game.special.SpecialSingleTileLay">
+				<SpecialSingleTileLay location="M15" colour="yellow" extra="yes" free="yes" />
 			</SpecialProperty>
-			<SpecialProperty condition="ifOwnedByPlayer" when="tileLayingStep" class="net.sf.rails.game.special.SpecialTileLay">
-				<SpecialTileLay location="M17" colour="yellow" extra="yes" free="yes" />
+			<SpecialProperty condition="ifOwnedByPlayer" when="tileLayingStep" class="net.sf.rails.game.special.SpecialSingleTileLay">
+				<SpecialSingleTileLay location="M17" colour="yellow" extra="yes" free="yes" />
 			</SpecialProperty>
 		</SpecialProperties>
 		<ClosingConditions>
@@ -67,8 +67,8 @@
 	</Company>
 	<Company name="PfB" longname="Pfalzbahnen" type="Private" basePrice="150" revenue="15">
 		<SpecialProperties>
-			<SpecialProperty condition="ifOwnedByPlayer" when="tileLayingStep" closesPrivate="no" class="net.sf.rails.game.special.SpecialTileLay">
-				<SpecialTileLay location="L6" colour="green" extra="yes" free="yes" />
+			<SpecialProperty condition="ifOwnedByPlayer" when="tileLayingStep" closesPrivate="no" class="net.sf.rails.game.special.SpecialSingleTileLay">
+				<SpecialSingleTileLay location="L6" colour="green" extra="yes" free="yes" />
 			</SpecialProperty>
 			<IfOption name="NF_PfB_Westermann" value ="yes">
 				<SpecialProperty condition="ifOwnedByPlayer" when="tokenLayingStep" class="net.sf.rails.game.special.SpecialBaseTokenLay">

--- a/src/main/resources/data/1837/CompanyManager.xml
+++ b/src/main/resources/data/1837/CompanyManager.xml
@@ -70,8 +70,8 @@
         <Company name="KwB" longname="Karawankenbahn" type="Private" basePrice="170" revenue="25">
                 <Blocking hex="J12"/>
                 <SpecialProperties>
-                        <SpecialProperty condition="ifOwnedByPlayer" when="tileLayingStep" class="net.sf.rails.game.special.SpecialTileLay">
-                                <SpecialTileLay location="J12" colour="yellow" extra="no" free="yes"/>
+                        <SpecialProperty condition="ifOwnedByPlayer" when="tileLayingStep" class="net.sf.rails.game.special.SpecialSingleTileLay">
+                                <SpecialSingleTileLay location="J12" colour="yellow" extra="no" free="yes"/>
                         </SpecialProperty>
                 </SpecialProperties>
                 <Info key="ComesWithPresidency" parm="S2,100"/>
@@ -79,8 +79,8 @@
         <Company name="BrB" longname="Brennerbahn" type="Private" basePrice="140" revenue="15">
                 <Blocking hex="J6"/>
                 <SpecialProperties>
-                        <SpecialProperty condition="ifOwnedByPlayer" when="tileLayingStep" class="net.sf.rails.game.special.SpecialTileLay">
-                                <SpecialTileLay location="J6" colour="yellow" extra="no" free="yes"/>
+                        <SpecialProperty condition="ifOwnedByPlayer" when="tileLayingStep" class="net.sf.rails.game.special.SpecialSingleTileLay">
+                                <SpecialSingleTileLay location="J6" colour="yellow" extra="no" free="yes"/>
                         </SpecialProperty>
                 </SpecialProperties>
                 <Info key="ComesWithPresidency" parm="S4,100"/>
@@ -88,16 +88,16 @@
         <Company name="WB" longname="Wocheinerbahn" type="Private" basePrice="130" revenue="30">
                 <Blocking hex="K11"/>
                 <SpecialProperties>
-                        <SpecialProperty condition="ifOwnedByPlayer" when="tileLayingStep" class="net.sf.rails.game.special.SpecialTileLay">
-                                <SpecialTileLay location="K11" colour="yellow" extra="no" free="yes"/>
+                        <SpecialProperty condition="ifOwnedByPlayer" when="tileLayingStep" class="net.sf.rails.game.special.SpecialSingleTileLay">
+                                <SpecialSingleTileLay location="K11" colour="yellow" extra="no" free="yes"/>
                         </SpecialProperty>
                 </SpecialProperties>
         </Company>
         <Company name="AB" longname="Arlbergbahn" type="Private" basePrice="185" revenue="20">
                 <Blocking hex="I5"/>
                 <SpecialProperties>
-                        <SpecialProperty condition="ifOwnedByPlayer" when="tileLayingStep" class="net.sf.rails.game.special.SpecialTileLay">
-                                <SpecialTileLay location="I5" colour="yellow" extra="no" free="yes"/>
+                        <SpecialProperty condition="ifOwnedByPlayer" when="tileLayingStep" class="net.sf.rails.game.special.SpecialSingleTileLay">
+                                <SpecialSingleTileLay location="I5" colour="yellow" extra="no" free="yes"/>
                         </SpecialProperty>
                 </SpecialProperties>
                 <Info key="ComesWithPresidency" parm="S3,100"/>
@@ -105,8 +105,8 @@
         <Company name="KB" longname="Karstbahn" type="Private" basePrice="120" revenue="10">
                 <Blocking hex="K13"/>
                 <SpecialProperties>
-                        <SpecialProperty condition="ifOwnedByPlayer" when="tileLayingStep" class="net.sf.rails.game.special.SpecialTileLay">
-                                <SpecialTileLay location="K13" colour="yellow" extra="no" free="yes"/>
+                        <SpecialProperty condition="ifOwnedByPlayer" when="tileLayingStep" class="net.sf.rails.game.special.SpecialSingleTileLay">
+                                <SpecialSingleTileLay location="K13" colour="yellow" extra="no" free="yes"/>
                         </SpecialProperty>
                 </SpecialProperties>
                 <Info key="ComesWithPresidency" parm="S5,100"/>
@@ -114,8 +114,8 @@
         <Company name="SmB" longname="Semmeringbahn" type="Private" basePrice="150" revenue="5">
                 <Blocking hex="H16"/>
                 <SpecialProperties>
-                        <SpecialProperty condition="ifOwnedByPlayer" when="tileLayingStep" class="net.sf.rails.game.special.SpecialTileLay">
-                                <SpecialTileLay location="H16" colour="yellow" extra="no" free="yes"/>
+                        <SpecialProperty condition="ifOwnedByPlayer" when="tileLayingStep" class="net.sf.rails.game.special.SpecialSingleTileLay">
+                                <SpecialSingleTileLay location="H16" colour="yellow" extra="no" free="yes"/>
                         </SpecialProperty>
                 </SpecialProperties>
                 <Info key="ComesWithPresidency" parm="S1,100"/>
@@ -123,8 +123,8 @@
         <Company name="TB" longname="Tauernbahn" type="Private" basePrice="150" revenue="35">
                 <Blocking hex="J10"/>
                 <SpecialProperties>
-                        <SpecialProperty condition="ifOwnedByPlayer" when="tileLayingStep" class="net.sf.rails.game.special.SpecialTileLay">
-                                <SpecialTileLay location="J10" colour="yellow" extra="no" free="yes"/>
+                        <SpecialProperty condition="ifOwnedByPlayer" when="tileLayingStep" class="net.sf.rails.game.special.SpecialSingleTileLay">
+                                <SpecialSingleTileLay location="J10" colour="yellow" extra="no" free="yes"/>
                         </SpecialProperty>
                 </SpecialProperties>
         </Company>

--- a/src/main/resources/data/1856/CompanyManager.xml
+++ b/src/main/resources/data/1856/CompanyManager.xml
@@ -36,8 +36,8 @@
 	<Company name="W&amp;SR" type="Private" basePrice="40" revenue="10">
 		<Blocking hex="I12"/>
 		<SpecialProperties>
-			<SpecialProperty condition="ifOwnedByCompany" when="tileLayingStep" class="net.sf.rails.game.special.SpecialTileLay">
-				<SpecialTileLay tile="59" location="I12" connected="no" extra="no"/>
+			<SpecialProperty condition="ifOwnedByCompany" when="tileLayingStep" class="net.sf.rails.game.special.SpecialSingleTileLay">
+				<SpecialSingleTileLay tile="59" location="I12" connected="no" extra="no"/>
 			</SpecialProperty>
 			<SpecialProperty condition="ifOwnedByCompany" when="tokenLayingStep" class="net.sf.rails.game.special.SpecialBaseTokenLay">
 				<SpecialBaseTokenLay location="I12" connected="no" extra="no" free="yes"/>
@@ -50,8 +50,8 @@
 	<Company name="TCC" type="Private" basePrice="50" revenue="10">
 		<Blocking hex="H11"/>
 		<SpecialProperties>
-			<SpecialProperty condition="ifOwnedByCompany" when="tileLayingStep" class="net.sf.rails.game.special.SpecialTileLay">
-				<SpecialTileLay location="H11" connected="no" extra="yes"/>
+			<SpecialProperty condition="ifOwnedByCompany" when="tileLayingStep" class="net.sf.rails.game.special.SpecialSingleTileLay">
+				<SpecialSingleTileLay location="H11" connected="no" extra="yes"/>
 			</SpecialProperty>
 		</SpecialProperties>
 	</Company>

--- a/src/main/resources/data/1889/CompanyManager.xml
+++ b/src/main/resources/data/1889/CompanyManager.xml
@@ -52,8 +52,8 @@
 			longName="Mitsubishi Ferry">
 <!-- 			Handling of special property outside of players public company turn is done in OperatingRound_1889, coded against name "B" -->
 			<SpecialProperties>
-				<SpecialProperty condition="ifOwnedByPlayer" when="tileLayingStep" class="net.sf.rails.game.special.SpecialTileLay">
-					<SpecialTileLay location="B11,G10,I12,J9" tile="437" extra="yes" free="yes"/>
+				<SpecialProperty condition="ifOwnedByPlayer" when="tileLayingStep" class="net.sf.rails.game.special.SpecialSingleTileLay">
+					<SpecialSingleTileLay location="B11,G10,I12,J9" tile="437" extra="yes" free="yes"/>
 				</SpecialProperty>
 			</SpecialProperties>
 		</Company>
@@ -62,16 +62,16 @@
 			<Blocking hex="C4"/>
 			<SpecialProperties>
 <!-- 			Timing of special property is done in OperatingRound_1889, coded against name "C" -->
-				<SpecialProperty condition="specific" when="tileLayingStep" class="net.sf.rails.game.special.SpecialTileLay">
-					<SpecialTileLay location="C4" colour="green" extra="yes" free="yes"/>
+				<SpecialProperty condition="specific" when="tileLayingStep" class="net.sf.rails.game.special.SpecialSingleTileLay">
+					<SpecialSingleTileLay location="C4" colour="green" extra="yes" free="yes"/>
 				</SpecialProperty>
 			</SpecialProperties>
 		</Company>
 		<Company name="D" type="Private" basePrice="50" revenue="15"
 			longName="Sumitomo Mines Railway">
 			<SpecialProperties>
-				<SpecialProperty condition="ifOwnedByCompany" when="tileLayingStep" permanent="yes" class="net.sf.rails.game.special.SpecialTileLay">
-					<SpecialTileLay location="A8,B9,C6,D5,D7,E4,E6,F5,F7,G6,G8,H9,H11,H13" extra="no" free="yes" connected="yes"/>
+				<SpecialProperty condition="ifOwnedByCompany" when="tileLayingStep" permanent="yes" class="net.sf.rails.game.special.SpecialSingleTileLay">
+					<SpecialSingleTileLay location="A8,B9,C6,D5,D7,E4,E6,F5,F7,G6,G8,H9,H11,H13" extra="no" free="yes" connected="yes"/>
 				</SpecialProperty>
 			</SpecialProperties>
 		</Company>

--- a/src/main/resources/data/18AL/CompanyManager.xml
+++ b/src/main/resources/data/18AL/CompanyManager.xml
@@ -35,8 +35,8 @@
 		longname="Brown &amp; Sons Lumber Co.">
 		<SpecialProperties>
 			<SpecialProperty condition="ifOwnedByCompany"
-				when="tileLayingStep" class="net.sf.rails.game.special.SpecialTileLay">
-				<SpecialTileLay tile="445" name="Lumber Terminal"
+				when="tileLayingStep" class="net.sf.rails.game.special.SpecialSingleTileLay">
+				<SpecialSingleTileLay tile="445" name="Lumber Terminal"
 					location="G2,M2,N5,O4,P5" connected="no" free="yes" extra="yes" />
 			</SpecialProperty>
 		</SpecialProperties>

--- a/src/main/resources/data/18C2C/CompanyManager.xml
+++ b/src/main/resources/data/18C2C/CompanyManager.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0"?>
 <!-- 18C2C CompanyManager.xml -->
 <CompanyManager>
-	
 	<CompanyType name="Private" class="net.sf.rails.game.PrivateCompany">
 		<Tradeable toCompany="yes" lowerPriceFactor="0.5" upperPriceFactor="2.0"/>
 	</CompanyType>
@@ -119,7 +118,7 @@
 	
 	<Company name="SP" type="Private" basePrice="20" revenue="5"
 		longname="The Southern Pacific Railroad">
-		<Blocking hex="S62/>
+		<Blocking hex="S62"/>
 		<ClosingConditions>
 			<Phase name="5"/>
 		</ClosingConditions>
@@ -129,7 +128,7 @@
 	
 	<Company name="SV" type="Private" basePrice="20" revenue="5"
 		longname="Schuylkill Valley">
-		<Blocking hex="K74/>
+		<Blocking hex="K74"/>
 		<ClosingConditions>
 			<Phase name="5"/>
 		</ClosingConditions>
@@ -140,11 +139,11 @@
 		<SpecialProperties>
 			<SpecialProperty condition="ifOwnedByCompany"
 				when="anyTimeDuringORTurn"
-				class="net.sf.rails.game.special.SpecialTileLay">
-				<SpecialTileLay class="net.sf.rails.game.BonusToken"
+				class="net.sf.rails.game.special.SpecialSingleTileLay">
+				<SpecialSingleTileLay class="net.sf.rails.game.BonusToken"
 					location=""
 					connected="yes" extra="no">
-				</SpecialTileLay>
+				</SpecialSingleTileLay>
 			</SpecialProperty>
 		</SpecialProperties>
 		<ClosingConditions>
@@ -214,7 +213,7 @@
 	
 	<Company name="C&amp;A" type="Private" basePrice="20" revenue="5"
 		longname="Camden &amp; Amboy">
-		<Blocking hex="L77/>
+		<Blocking hex="L77"/>
 		<ClosingConditions>
 			<Phase name="5"/>
 		</ClosingConditions>
@@ -223,7 +222,7 @@
 	
 	<Company name="Sou" type="Private" basePrice="20" revenue="5"
 		longname="The Southern Railroad">
-		<Blocking hex="S62/>
+		<Blocking hex="S62"/>
 		<ClosingConditions>
 			<Phase name="5"/>
 		</ClosingConditions>
@@ -270,7 +269,7 @@
 		<Destination hex="A4,A6"/>
 	</Company>
 
-	<Company name="C&O" type="Public" tokens="5" fgColour="0000FF" bgColour="FFFFFF"
+	<Company name="C&amp;O" type="Public" tokens="5" fgColour="0000FF" bgColour="FFFFFF"
 		longname="Chesapeake &amp; Ohio Railroad">
 		<Home hex="J65"/>
 		<Destination hex="O72"/>
@@ -284,14 +283,14 @@
 		</Company>
 	</IfOption>
 
-	<Company name="CB&Q" type="Public" tokens="4" fgColour="FFFFFF" bgColour="848200"
+	<Company name="CB&amp;Q" type="Public" tokens="4" fgColour="FFFFFF" bgColour="848200"
 		longname="Chicago, Burlington &amp; Quincy Railroad">
 		<Home hex="K52"/>
 		<Destination hex="L29"/>
 	</Company>
 
 	<IfOption name="ShortGame" value="no">
-		<Company name="CRI&P" type="Public" tokens="5" fgColour="FFFFFF" bgColour="003000"
+		<Company name="CRI&amp;P" type="Public" tokens="5" fgColour="FFFFFF" bgColour="003000"
 			longname="Chicago, Rock Island &amp; Pacific Railroad">
 			<Home hex="J47"/>
 			<Destination hex="N29"/>
@@ -299,7 +298,7 @@
 	</IfOption>
 
 	<IfOption name="ShortGame" value="no">
-		<Company name="CMStP&P" type="Public" tokens="5" fgColour="FFFFFF" bgColour="840084"
+		<Company name="CMStP&amp;P" type="Public" tokens="5" fgColour="FFFFFF" bgColour="840084"
 			longname="Chicago, Milwaukee, St. Paul &amp; Pacific">
 			<Home hex="F49"/>
 			<Destination hex="C4"/>
@@ -307,7 +306,7 @@
 	</IfOption>
 
 	<IfOption name="ShortGame" value="no">
-		<Company name="D&RGW" type="Public" tokens="4" fgColour="FFFFFF" bgColour="FF0000"
+		<Company name="D&amp;RGW" type="Public" tokens="4" fgColour="FFFFFF" bgColour="FF0000"
 			longname="Denver &amp; Rio Grande Western Railroad">
 			<Home hex="L29"/>
 			<Destination hex="C4"/>
@@ -340,7 +339,7 @@
 		<Destination hex="J57"/>
 	</Company>
 
-	<Company name="L&N" type="Public" tokens="5" fgColour="FFFFFF" bgColour="000084"
+	<Company name="L&amp;N" type="Public" tokens="5" fgColour="FFFFFF" bgColour="000084"
 		longname="Louisville &amp; Nashville Railroad">
 		<Home hex="N59"/>
 		<Destination hex="W54"/>
@@ -364,13 +363,13 @@
 		<Destination hex="J57"/>
 	</Company>
 
-	<Company name="NYNH&H" type="Public" tokens="4" fgColour="FFFFFF" bgColour="FF6500"
+	<Company name="NYNH&amp;H" type="Public" tokens="4" fgColour="FFFFFF" bgColour="FF6500"
 		longname="New York, New Haven &amp; Hartford Railroad">
 		<Home hex="K78" city="1"/>
 		<Destination hex="E88"/>
 	</Company>
 
-	<Company name="N&W" type="Public" tokens="5" fgColour="840000" bgColour="FFFFFF"
+	<Company name="N&amp;W" type="Public" tokens="5" fgColour="840000" bgColour="FFFFFF"
 		longname="Norfolk and Western Railroad">
 		<Home hex="P73"/>
 		<Destination hex="W54"/>

--- a/src/main/resources/data/18GA/CompanyManager.xml
+++ b/src/main/resources/data/18GA/CompanyManager.xml
@@ -22,14 +22,14 @@
 		<CanUseSpecialProperties/>
 	</CompanyType>
 	<Company name="LT" type="Private" basePrice="20" revenue="5"
-		longname="Lexington Terminal Railroad"></Company>
+			 longname="Lexington Terminal Railroad"/>
 	<Company name="MR" type="Private" basePrice="40" revenue="10"
 		longname="Midland Railroad">
 		<Blocking hex="F12"/>
 		<SpecialProperties>
 			<SpecialProperty condition="ifOwnedByCompany" when="tileLayingStep"
-				class="net.sf.rails.game.special.SpecialTileLay">
-				<SpecialTileLay location="F12" extra="yes" free="yes"/>
+				class="net.sf.rails.game.special.SpecialSingleTileLay">
+				<SpecialSingleTileLay location="F12" extra="yes" free="yes"/>
 			</SpecialProperty>
 		</SpecialProperties>
 	</Company>

--- a/src/main/resources/data/18Kaas/CompanyManager.xml
+++ b/src/main/resources/data/18Kaas/CompanyManager.xml
@@ -22,16 +22,16 @@
 	<Company name="C&amp;StL" type="Private" basePrice="40" revenue="10">
 		<Blocking hex="D15"/>
 		<SpecialProperties>
-			<SpecialProperty condition="ifOwnedByCompany" when="tileLayingStep" class="net.sf.rails.game.special.SpecialTileLay">
-				<SpecialTileLay location="D15" extra="yes"/>
+			<SpecialProperty condition="ifOwnedByCompany" when="tileLayingStep" class="net.sf.rails.game.special.SpecialSingleTileLay">
+				<SpecialSingleTileLay location="D15" extra="yes"/>
 			</SpecialProperty>
 		</SpecialProperties>
 	</Company>
 	<Company name="D&amp;H" type="Private" basePrice="70" revenue="15">
 		<Blocking hex="K16"/>
 		<SpecialProperties>
-			<SpecialProperty condition="ifOwnedByCompany" when="tileLayingStep" class="net.sf.rails.game.special.SpecialTileLay">
-				<SpecialTileLay location="K16" extra="no" free="no"/>
+			<SpecialProperty condition="ifOwnedByCompany" when="tileLayingStep" class="net.sf.rails.game.special.SpecialSingleTileLay">
+				<SpecialSingleTileLay location="K16" extra="no" free="no"/>
 			</SpecialProperty>
 			<SpecialProperty condition="ifOwnedByCompany" when="tokenLayingStep" class="net.sf.rails.game.special.SpecialBaseTokenLay">
 				<SpecialBaseTokenLay location="K16" extra="no" free="yes"/>

--- a/src/main/resources/data/18NL/CompanyManager.xml
+++ b/src/main/resources/data/18NL/CompanyManager.xml
@@ -27,8 +27,8 @@
 			longname="Private 1">
 		<Blocking hex="F5"/>
 		<SpecialProperties>
-			<SpecialProperty condition="ifOwnedByCompany" when="tileLayingStep" class="net.sf.rails.game.special.SpecialTileLay">
-				<SpecialTileLay colour="yellow" location="F5" extra="yes" free="no" discount="20" />
+			<SpecialProperty condition="ifOwnedByCompany" when="tileLayingStep" class="net.sf.rails.game.special.SpecialSingleTileLay">
+				<SpecialSingleTileLay colour="yellow" location="F5" extra="yes" free="no" discount="20" />
 			</SpecialProperty>
 		</SpecialProperties>
 	</Company>

--- a/src/main/resources/data/18TN/CompanyManager.xml
+++ b/src/main/resources/data/18TN/CompanyManager.xml
@@ -28,32 +28,32 @@
 	<Company name="TCC" type="Private" basePrice="20" revenue="5"
 			longname="Tennessee Copper Company">
 		<SpecialProperties>
-			<SpecialProperty condition="ifOwnedByCompany" when="tileLayingStep" class="net.sf.rails.game.special.SpecialTileLay">
-				<SpecialTileLay location="H17" extra="yes" free="yes"/>
+			<SpecialProperty condition="ifOwnedByCompany" when="tileLayingStep" class="net.sf.rails.game.special.SpecialSingleTileLay">
+				<SpecialSingleTileLay location="H17" extra="yes" free="yes"/>
 			</SpecialProperty>
 		</SpecialProperties>
 	</Company>
 	<Company name="ET&amp;WNC" type="Private" basePrice="40" revenue="10"
 			longname="East Tennessee and Western North Carolina">
 		<SpecialProperties>
-			<SpecialProperty condition="ifOwnedByCompany" when="tileLayingStep" class="net.sf.rails.game.special.SpecialTileLay">
-				<SpecialTileLay location="F19" extra="yes" free="yes"/>
+			<SpecialProperty condition="ifOwnedByCompany" when="tileLayingStep" class="net.sf.rails.game.special.SpecialSingleTileLay">
+				<SpecialSingleTileLay location="F19" extra="yes" free="yes"/>
 			</SpecialProperty>
 		</SpecialProperties>
 	</Company>
 	<Company name="M&amp;C" type="Private" basePrice="70" revenue="15"
 			longname="Memphis and Charleston Railroad">
 		<SpecialProperties>
-			<SpecialProperty condition="ifOwnedByCompany" when="tileLayingStep" class="net.sf.rails.game.special.SpecialTileLay">
-				<SpecialTileLay location="H3" extra="yes" free="yes"/>
+			<SpecialProperty condition="ifOwnedByCompany" when="tileLayingStep" class="net.sf.rails.game.special.SpecialSingleTileLay">
+				<SpecialSingleTileLay location="H3" extra="yes" free="yes"/>
 			</SpecialProperty>
 		</SpecialProperties>
 	</Company>
 	<Company name="O&amp;W" type="Private" basePrice="100" revenue="20"
 			longname="Oneida and Western Railroad">
 		<SpecialProperties>
-			<SpecialProperty condition="ifOwnedByCompany" when="tileLayingStep" class="net.sf.rails.game.special.SpecialTileLay">
-				<SpecialTileLay location="E16" extra="yes" free="yes"/>
+			<SpecialProperty condition="ifOwnedByCompany" when="tileLayingStep" class="net.sf.rails.game.special.SpecialSingleTileLay">
+				<SpecialSingleTileLay location="E16" extra="yes" free="yes"/>
 			</SpecialProperty>
 		</SpecialProperties>
 	</Company>


### PR DESCRIPTION
18xx Base Routines in Preparation for Multiple Tile Lays as a Special Property: Changes to SpecialTileLay by making that an abstract Class and implementing SpecialSingleTileLay.  
Adjusting the Configurations of various games that used the old SpecialTileLay