### PR TITLE
SOH completed

### DIFF
--- a/src/main/java/net/sf/rails/game/OperatingRound.java
+++ b/src/main/java/net/sf/rails/game/OperatingRound.java
@@ -2967,9 +2967,18 @@ public class OperatingRound extends Round implements Observer {
             }
 
             /* Check if this is an emergency buy */
-            //if (action.mustPresidentAddCash()) {
             int cashToRaise = Math.max(0, trainPrice - companyCash);
-            if (cashToRaise > 0) {
+            if (emergency || cashToRaise > 0) { // Not all games set emergency yet
+                if (willBankruptcyOccur(company, cashToRaise)) {
+                    DisplayBuffer.add(this, LocalText.getText("YouMustRaiseCashButCannot",
+                            Bank.format(this, cashToRaise)));
+                    if (GameDef.getParmAsBoolean(this, GameDef.Parm.EMERGENCY_COMPANY_BANKRUPTCY)) {
+                        company.setBankrupt();
+                        gameManager.registerCompanyBankruptcy();
+
+                        return true;
+                    }
+                }
 
                 // In some games (SOH) company must sell treasury shares first
                 if (GameDef.getParmAsBoolean(this, GameDef.Parm.EMERGENCY_MUST_SELL_TREASURY_SHARES)) {
@@ -3206,6 +3215,24 @@ public class OperatingRound extends Round implements Observer {
 
         }
         return !excessTrainCompanies.isEmpty();
+    }
+
+    /**
+     * Predict if bankruptcy will occur in emergency train buying.
+     * Must be called <i>after</i> the president has selected a train to buy,
+     * and only if treasury cash is insufficient to buy a selected train.
+     *
+     * Currently a stub, only called in SOH (see OperatingRound_SOH).
+     * May be useful in other cases, in which case the code will likely move to here.
+     *
+     * @param owner Either a player or a PublicCompany.
+     *              Only tested for the latter (SOH).
+     * @param cashToRaise The extra cash amount needed to buy a selected train.
+     * @return True if bankruptcy is inevitable.
+     */
+    public boolean willBankruptcyOccur(Owner owner,
+                                       int cashToRaise) {
+        return false;
     }
 
     /**

--- a/src/main/java/net/sf/rails/game/Round.java
+++ b/src/main/java/net/sf/rails/game/Round.java
@@ -270,7 +270,7 @@ public abstract class Round extends RailsAbstractItem implements RoundFacade {
     }
 
     // Could be moved somewhere else (RoundUtils?)
-    // called only internally
+    // called only internally. EV: why is that an issue?
     protected void finishRound() {
         // Report financials
         ReportBuffer.add(this, "");

--- a/src/main/java/net/sf/rails/game/financial/PlayerShareUtils.java
+++ b/src/main/java/net/sf/rails/game/financial/PlayerShareUtils.java
@@ -54,7 +54,7 @@ public class PlayerShareUtils {
 
         int maxShares;
         if (potential == null) {
-            // ... if there is none, selling is only possible until the presidentCerificate or pool maximum
+            // ... if there is none, selling is only possible until the presidentCertificate or pool maximum
             maxShares = Math.min(presidentShares - presidentCertificateShares, poolShares);
         } else { 
             // otherwise until pool maximum only

--- a/src/main/java/net/sf/rails/game/financial/ShareSellingRound.java
+++ b/src/main/java/net/sf/rails/game/financial/ShareSellingRound.java
@@ -431,9 +431,9 @@ public class ShareSellingRound extends StockRound {
                 DisplayBuffer.add(this, LocalText.getText("YouMustRaiseCashButCannot",
                         Bank.format(this, cashToRaise.value())));
                 if (GameDef.getParmAsBoolean(this, GameDef.Parm.EMERGENCY_COMPANY_BANKRUPTCY)) {
+                    // Currently not used, replaced by code in operatingRound.buyTrain().
                     cashNeedingCompany.setBankrupt();
                     gameManager.registerCompanyBankruptcy();
-                    finishRound();
                 } else {
                     currentPlayer.setBankrupt();
                     gameManager.registerPlayerBankruptcy();

--- a/src/main/java/net/sf/rails/game/financial/TreasuryShareRound.java
+++ b/src/main/java/net/sf/rails/game/financial/TreasuryShareRound.java
@@ -148,6 +148,9 @@ public class TreasuryShareRound extends StockRound {
      * presidencies of other companies has been retained, but not tested. This
      * code will be needed for 1841.
      *
+     * TODO: There is much almost-duplicate code in this and other (pseudo-)stock rounds,
+     * and also in the SOH operating round. Perhaps some more generic code can be written.
+     *
      * @return List of sellable certificates.
      */
     public void setSellableCerts() {

--- a/src/main/java/net/sf/rails/game/state/StateManager.java
+++ b/src/main/java/net/sf/rails/game/state/StateManager.java
@@ -78,7 +78,7 @@ public final class StateManager extends Manager {
     /**
      * Adds the combination of observer to observable
      * Usually this is one via addObserver of the observable
-     * @throws an IllegalArgumentException - if observer is already assigned to an observable
+     * @throws IllegalArgumentException - if observer is already assigned to an observable
      */
     synchronized void addObserver(Observer observer, Observable observable) {
         checkArgument(!observers.containsValue(observer), "Observer can only be assigned to one Observable");
@@ -101,8 +101,8 @@ public final class StateManager extends Manager {
 
     /**
      * Adds the combination of model to observable
-     * @param Model the model that is updated by the observable
-     * @param Observable the observable to monitor
+     * @param model the model that is updated by the observable
+     * @param observable the observable to monitor
      */
     void addModel(Model model, Observable observable) {
         models.put(observable, model);
@@ -118,8 +118,8 @@ public final class StateManager extends Manager {
 
     /**
      * Adds the combination of trigger to observable
-     * @param Triggerable the trigger that tracks the observable
-     * @param Observable the observable to monitor
+     * @param trigger the trigger that tracks the observable
+     * @param observable the observable to monitor
      */
     void addTrigger(Triggerable trigger, Observable observable) {
         triggers.put(observable, trigger);

--- a/src/main/java/net/sf/rails/ui/swing/GameStatus.java
+++ b/src/main/java/net/sf/rails/ui/swing/GameStatus.java
@@ -366,8 +366,9 @@ public class GameStatus extends GridPanel implements ActionListener {
         for (int i = 0; i < nc; i++) {
             c = companies[i];
             companyIndex.put(c, i);
-            rowVisibilityObservers[i]
-                                   = new RowVisibility(this, certPerPlayerYOffset + i, c.getInGameModel(), false);
+            rowVisibilityObservers[i] = new RowVisibility(
+                    this, certPerPlayerYOffset + i,
+                    c.getInGameModel(), false);
             boolean visible = rowVisibilityObservers[i].lastValue();
 
             f = new Caption(c.getId());

--- a/src/main/java/net/sf/rails/util/RailsObjects.java
+++ b/src/main/java/net/sf/rails/util/RailsObjects.java
@@ -111,7 +111,7 @@ public class RailsObjects {
         }
 
         public StringHelperForActions addToString(String name, Object value) {
-            value = testIfNull(value, "NULL");
+            value = testIfNull(value, "null");
             
             text.append(", " + name + "=" +  value.toString());
             return this;

--- a/src/main/java/rails/game/action/BuyTrain.java
+++ b/src/main/java/rails/game/action/BuyTrain.java
@@ -264,6 +264,9 @@ public class BuyTrain extends PossibleORAction {
         // To shorten this long text, the booleans are made implicit
         String addCash = presidentMustAddCash ? "presMustAdd" :
                           presidentMayAddCash ? "presMayAdd" : "cashToAdd";
+        String useSP = specialProperty != null
+                ? specialProperty.getOriginalCompany().getId()
+                : null;
         return super.toString() +
                 RailsObjects.stringHelper(this)
                     .addToString("train", train)
@@ -271,6 +274,7 @@ public class BuyTrain extends PossibleORAction {
                     .addToString("fixedCost", fixedCost)
                     .addToString("trainsForExchange", trainsForExchange)
                     .addToString(addCash, presidentCashToAdd)
+                    .addToString("useSP", useSP)
                     .addToStringOnlyActed("pricePaid", pricePaid)
                     .addToStringOnlyActed("addedCash", addedCash)
                     .addToStringOnlyActed("exchangedTrain", exchangedTrainUniqueId)

--- a/src/main/java/rails/game/action/PossibleActions.java
+++ b/src/main/java/rails/game/action/PossibleActions.java
@@ -11,7 +11,7 @@ import com.google.common.collect.Lists;
  * in time. Each possible action is represented by an instance of a subclass of
  * PossibleAction. The complete set is stored in an ArrayList.
  * 
- * TODO: Should this be changed to a set?
+ * TODO: Should this be changed to a set? EV: Why? No, unless sequence can be kept.
  */
 public class PossibleActions {
 
@@ -92,7 +92,7 @@ public class PossibleActions {
             return true;
         }
 
-        // Check if action accurs in the list of possible actions
+        // Check if action occurs in the list of possible actions
         for (PossibleAction action : actions) {
             if (action.equalsAsOption(checkedAction)) {
                 return true;

--- a/src/main/resources/LocalisedText.properties
+++ b/src/main/resources/LocalisedText.properties
@@ -11,10 +11,11 @@
 1889PrivateCactive=Player {0} (previous owner of Private C) may lay tile on C4 immediately
 18ALOptimizeNamedTrains=Optimize named train assignment
 18KaasRuhrgebiedDoublesOnlyMajors=Ruhrgebiet bonus applies for cities only
-# 4D-trains
-4D=4D
-# 8-trains
+# Train ids used as GameOption parameters (unlimited top trains)
+6=6
 8=8
+3E=3E
+4D=4D
 aconnected=a connected
 anunconnected=an unconnected
 ActionNotAllowed=Action {0} is not allowed

--- a/src/main/resources/data/GamesList.xml
+++ b/src/main/resources/data/GamesList.xml
@@ -194,7 +194,7 @@ Not yet implemented:
 	</Game>
 
 	<Game name="SOH">
-		<Note>Playable</Note>
+		<Note>Fully Playable</Note>
 		<Description>Steam over Holland
 			(c) 2007 Bart van Dijk
 			Published 2007 by Vendetta Games
@@ -213,9 +213,6 @@ Not yet implemented:
 			3. Select. Each player gets one turn, to choose and buy any private for base price,
 			or pass. This scenario was added for testing purposes, and possibly for players who
 			want to distribute privates off-game in their own way. Still maximum one per player.
-
-			Not yet implemented:
-			- Company bankruptcy
 		</Description>
 		<Players minimum="2" maximum="5"/>
 	</Game>


### PR DESCRIPTION
Implemented SOH company bankruptcy rules. 

Added OperatingRound.willBankruptcyOccur() to predict if an emergency train can be financed. Now a stub, functional code only exists in the SOH subclass. This method circumvents the need to open both TreasuryShareRound and ShareSellingRound, and the need to undo all selling actions in case of bankruptcy. 