### PR TITLE
1880-Fixes-for-2.2.2

### DIFF
--- a/src/main/java/net/sf/rails/ui/swing/gamespecific/_1880/InvestorPanel.java
+++ b/src/main/java/net/sf/rails/ui/swing/gamespecific/_1880/InvestorPanel.java
@@ -21,12 +21,10 @@ public class InvestorPanel {
     public InvestorPanel(GameManager_1880 gameManager) {
 
         List<Investor_1880> investors = Investor_1880.getInvestors(gameManager.getRoot().getCompanyManager());
-        List<Investor_1880> investors_new = new ArrayList<Investor_1880>();
+        List<Investor_1880> investors_new = new ArrayList<>();
 
         for (Investor_1880 inv : investors) {
-            if (!inv.isClosed()) {
-                investors_new.add(inv);
-            }
+            if (inv.hasOperated()) investors_new.add(inv);
         }
 
         GridAxis rows = GridAxis.builder()

--- a/src/main/resources/data/1880/Tiles.xml
+++ b/src/main/resources/data/1880/Tiles.xml
@@ -83,8 +83,8 @@
 <Track from="city1" gauge="normal" to="side0"/>
 </Tile>
 <Tile colour="yellow" id="235" name="235">
-<Station id="city1" position="502" slots="1" type="City" value="20"/>
-<Station id="city2" position="252" slots="1" type="City" value="20"/>
+<Station id="city1" position="502" slots="1" type="City" value="30"/>
+<Station id="city2" position="252" slots="1" type="City" value="30"/>
 <Track from="city1" gauge="normal" to="side5"/>
 </Tile>
 <Tile colour="yellow" id="8850" name="8850">


### PR DESCRIPTION
fixes for 2 new small errors in 1880, Tile 235 had the wrong value for its cities.
The newly introduced InvestorPanel now doesnt crash the game on start anymore.