### PR TITLE
1837: Improvements and bug fixes, part III

### DIFF
--- a/src/main/java/net/sf/rails/common/parser/Tag.java
+++ b/src/main/java/net/sf/rails/common/parser/Tag.java
@@ -276,18 +276,24 @@ public class Tag {
                         value = attribute.getNodeValue();
                         attributes.put(name, value);
                     }
-                } else if ( "IfOption".equalsIgnoreCase(childTagName)) {
-                    Node nameAttr = nnp.getNamedItem("name");
-                    if (nameAttr == null)
-                        throw new ConfigurationException(
-                                "IfOption has no optionName attribute");
-                    name = nameAttr.getNodeValue();
+                } else if ("IfOption".equalsIgnoreCase(childTagName)
+                        || "IfVariant".equalsIgnoreCase(childTagName)) {
 
-                    Node parmAttr = nnp.getNamedItem("parm");
-                    if (parmAttr != null) {
-                        value = parmAttr.getNodeValue();
-                        Iterable<String> parameters = Splitter.on(XMLTags.VALUES_DELIM).split(value);
-                        name = GameOption.constructParameterisedName(name, ImmutableList.copyOf(parameters));
+                    if ("IfOption".equalsIgnoreCase(childTagName)) {
+                        Node nameAttr = nnp.getNamedItem("name");
+                        if (nameAttr == null)
+                            throw new ConfigurationException(
+                                    "IfOption has no optionName attribute");
+                        name = nameAttr.getNodeValue();
+
+                        Node parmAttr = nnp.getNamedItem("parm");
+                        if (parmAttr != null) {
+                            value = parmAttr.getNodeValue();
+                            Iterable<String> parameters = Splitter.on(XMLTags.VALUES_DELIM).split(value);
+                            name = GameOption.constructParameterisedName(name, ImmutableList.copyOf(parameters));
+                        }
+                    } else {  // IfVariant
+                        name = "Variant";
                     }
 
                     Node valueAttr = nnp.getNamedItem("value");

--- a/src/main/java/net/sf/rails/game/StartItem.java
+++ b/src/main/java/net/sf/rails/game/StartItem.java
@@ -37,6 +37,10 @@ public class StartItem extends RailsAbstractItem {
     protected int column = 0;
     protected int index;
 
+    // To allow the displayed name to include both primary and secondary.
+    // Default is the primary name (id) only.
+    protected String displayName = null;
+
     // Bids
     protected final GenericState<Player> lastBidder = new GenericState<>(this, "lastBidder");
     protected final Map<Player, CountingMoneyModel> bids = Maps.newHashMap();
@@ -269,6 +273,14 @@ public class StartItem extends RailsAbstractItem {
      */
     public Certificate getSecondary() {
         return secondary;
+    }
+
+    public String getDisplayName() {
+        return (displayName != null ? displayName : getId());
+    }
+
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
     }
 
     /**

--- a/src/main/java/net/sf/rails/game/TileUpgrade.java
+++ b/src/main/java/net/sf/rails/game/TileUpgrade.java
@@ -383,12 +383,13 @@ public class TileUpgrade implements Upgrade {
             log.debug("base={} target={}", base, target);
         }
         // check if there are stations to map
-        Map<Station, Station> stationMapping = assignStations(base, target);
+       Map<Station, Station> stationMapping = assignStations(base, target);
 
         // Try something else: match sides with old and new Stations in a simple way
         // Each pair of stations that matches with the same side is connected.
         // This finally appears to work for the 1837 green Vienna upgrade.
         // Though it may only work where both base and target tiles have a fixed orientation.
+        // (may be obsolete, now that automatic relay works better (see issue #341).
         if (stationMapping == null) {
             stationMapping = new HashMap<>(6);
             Station b, t;
@@ -506,8 +507,11 @@ public class TileUpgrade implements Upgrade {
                 }
             }
             // check if all base and target stations are assigned
-            if (stationMap.keySet().size() != baseNb ||
-                    Sets.newHashSet(stationMap.values()).size() != targetNb) {
+            if (stationMap.keySet().size() != baseNb
+                /* Unclear why the all-stations-mapped check was applied to the new tile.
+                It inhibited upgrading 1837 Vienna to green (4 -> 6 stations).
+                || Sets.newHashSet(stationMap.values()).size() != targetNb*/
+            ) {
                 stationMap = null;
                 log.debug("Mapping: Not all stations assigned, set stationMap to null");
             }

--- a/src/main/java/net/sf/rails/ui/swing/ORUIManager.java
+++ b/src/main/java/net/sf/rails/ui/swing/ORUIManager.java
@@ -788,8 +788,9 @@ public class ORUIManager implements DialogOwner {
         Tile newTile = action.getLaidTile();
         Tile oldTile = hex.getCurrentTile();
 
-        // Why does that need to be configured?
-        // Shouldn't tokens always be relaid??
+        // Check if manual token relay is required.
+        // This was an emergency measure in cases where automatic relay
+        // did not work (e.g. 1837 tile 427). Now probably obsolete.
         if (!action.isRelayBaseTokens()
                 && !oldTile.relayBaseTokensOnUpgrade()) return; // is deprecated
 
@@ -798,7 +799,6 @@ public class ORUIManager implements DialogOwner {
         /* Check which tokens must be relaid, and in which sequence.
          * Ideally, the game engine should instruct the UI what to do
          * if there is more than one stop and more than one token.
-         * TODO LayTile does not yet allow that.
          *
          * For now, the only case that needs special handling is the 1835 BA home hex L6,
          * where it it possible to have two tokens laid before even one tile.

--- a/src/main/java/net/sf/rails/ui/swing/StartRoundWindow.java
+++ b/src/main/java/net/sf/rails/ui/swing/StartRoundWindow.java
@@ -13,7 +13,6 @@ import net.sf.rails.common.LocalText;
 import net.sf.rails.game.*;
 import net.sf.rails.game.financial.*;
 import net.sf.rails.game.round.RoundFacade;
-import net.sf.rails.game.special.SpecialProperty;
 import net.sf.rails.sound.SoundManager;
 import net.sf.rails.ui.swing.elements.*;
 import net.sf.rails.ui.swing.hexmap.HexHighlightMouseListener;
@@ -64,26 +63,34 @@ public class StartRoundWindow extends JFrame implements ActionListener, KeyListe
     private GridBagConstraints gbc;
 
     // Grid elements per function
-    private Caption itemName[];
-    private ClickField itemNameButton[];
-    private int itemNameXOffset, itemNameYOffset;
-    private Field basePrice[];
-    private int basePriceXOffset, basePriceYOffset;
-    private Field minBid[];
-    private int minBidXOffset, minBidYOffset;
-    private Field bidPerPlayer[][];
-    private int bidPerPlayerXOffset, bidPerPlayerYOffset;
-    private Field playerBids[];
-    private int playerBidsXOffset, playerBidsYOffset;
-    private Field playerFree[];
-    private int playerFreeCashXOffset, playerFreeCashYOffset;
-    private Field info[];
-    private int infoXOffset, infoYOffset;
-    private Field itemStatus[]; // Remains invisible, only used for status tooltip
+    private Caption[] itemName;
+    private ClickField[] itemNameButton;
+    private int[] itemNameXOffset;
+    private int itemNameYOffset;
+    private Field[] basePrice;
+    private int[] basePriceXOffset;
+    private int basePriceYOffset;
+    private Field[] minBid;
+    private int[] minBidXOffset;
+    private int minBidYOffset;
+    private Field[][] bidPerPlayer;
+    private int[] bidPerPlayerXOffset;
+    private int bidPerPlayerYOffset;
+    private Field[] playerBids;
+    private int[] playerBidsXOffset;
+    private int playerBidsYOffset;
+    private Field[] playerFree;
+    private int[] playerFreeCashXOffset;
+    private int playerFreeCashYOffset;
+    private Field[] info;
+    private int[] infoXOffset;
+    private int infoYOffset;
+    private Field[] itemStatus; // Remains invisible, only used for status tooltip
 
-    private int playerCaptionXOffset, upperPlayerCaptionYOffset, lowerPlayerCaptionYOffset;
-    private Field upperPlayerCaption[];
-    private Field lowerPlayerCaption[];
+    private int[] playerCaptionXOffset;
+    private int upperPlayerCaptionYOffset, lowerPlayerCaptionYOffset;
+    private Field[][] upperPlayerCaption;
+    private Field[] lowerPlayerCaption;
     private JComponent[][] fields;
 
     private ActionButton bidButton;
@@ -99,6 +106,11 @@ public class StartRoundWindow extends JFrame implements ActionListener, KeyListe
     private int[] crossIndex;
     protected StartRound round;
     private GameUIManager gameUIManager;
+    protected StartPacket startPacket;
+    protected boolean multipleColumns;
+    protected int numberOfColumns;
+    protected int numberOfRows;
+    protected int columnWidth = 0;
 
     // For the non-modal dialog to ask for a company starting share price.
     protected JDialog currentDialog;
@@ -118,6 +130,15 @@ public class StartRoundWindow extends JFrame implements ActionListener, KeyListe
     public void init(StartRound round, GameUIManager parent) {
         //super();
         this.round = round;
+        startPacket = round.getStartPacket();
+        multipleColumns = startPacket.isMultipleColumns();
+        if (multipleColumns) {
+            numberOfColumns = startPacket.getNumberOfColumns();
+            numberOfRows = startPacket.getNumberOfRows();
+        } else {
+            numberOfRows = round.getNumberOfStartItems();
+            numberOfColumns = 1;
+        }
         includeBidding = round.hasBidding();
         includeBuying = round.hasBuying();
         showBasePrices = round.hasBasePrices();
@@ -227,6 +248,7 @@ public class StartRoundWindow extends JFrame implements ActionListener, KeyListe
         int np = players.getNumberOfPlayers();
         int ni = round.getNumberOfStartItems();
 
+
         itemName = new Caption[ni];
         itemNameButton = new ClickField[ni];
         basePrice = new Field[ni];
@@ -234,91 +256,128 @@ public class StartRoundWindow extends JFrame implements ActionListener, KeyListe
         bidPerPlayer = new Field[ni][np];
         info = new Field[ni];
         itemStatus = new Field[ni];
-        upperPlayerCaption = new Field[np];
+        upperPlayerCaption = new Field[numberOfColumns][np];
         lowerPlayerCaption = new Field[np];
         playerBids = new Field[np];
         playerFree = new Field[np];
 
+        itemNameXOffset = new int[numberOfColumns];
+        if (showBasePrices) basePriceXOffset = new int[numberOfColumns];
+        if (includeBidding == StartRound.Bidding.ON_ITEMS) minBidXOffset = new int[numberOfColumns];
+        bidPerPlayerXOffset = new int[numberOfColumns];
+        playerCaptionXOffset = new int[numberOfColumns];
+        infoXOffset = new int[numberOfColumns];
+        if (includeBidding != StartRound.Bidding.NO) playerBidsXOffset = new int[numberOfColumns];
+        playerFreeCashXOffset = new int[numberOfColumns];
+
         upperPlayerCaptionYOffset = ++lastY;
 
-        itemNameXOffset = ++lastX;
-        itemNameYOffset = ++lastY;
-        if (showBasePrices) {
-            basePriceXOffset = ++lastX;
-            basePriceYOffset = lastY;
-        }
-        if (includeBidding == StartRound.Bidding.ON_ITEMS) {
-            minBidXOffset = ++lastX;
-            minBidYOffset = lastY;
-        }
-        bidPerPlayerXOffset = playerCaptionXOffset = ++lastX;
-        bidPerPlayerYOffset = lastY;
+        for (int col = 0; col < numberOfColumns; col++) {
+            itemNameXOffset[col] = ++lastX;
+            if (col == 0) itemNameYOffset = ++lastY;
+            if (showBasePrices) {
+                basePriceXOffset[col] = ++lastX;
+                if (col == 0) basePriceYOffset = lastY;
+            }
+            if (includeBidding == StartRound.Bidding.ON_ITEMS) {
+                minBidXOffset[col] = ++lastX;
+                if (col == 0) minBidYOffset = lastY;
+            }
+            bidPerPlayerXOffset[col] = playerCaptionXOffset[col] = ++lastX;
+            if (col == 0) bidPerPlayerYOffset = lastY;
 
-        infoXOffset = bidPerPlayerXOffset + np;
-        infoYOffset = lastY;
+            infoXOffset[col] = bidPerPlayerXOffset[col] + np;
+            lastX += np;
+            if (col == 0) {
+                infoYOffset = lastY;
+                columnWidth = lastX + 1;
+            }
 
-        // Bottom rows
-        lastY += (ni - 1);
-        if (includeBidding != StartRound.Bidding.NO) {
-            playerBidsXOffset = bidPerPlayerXOffset;
-            playerBidsYOffset = ++lastY;
+
+            // Bottom rows
+            lastY += (numberOfRows - 1);
+            if (includeBidding != StartRound.Bidding.NO) {
+                playerBidsXOffset[col] = bidPerPlayerXOffset[col];
+                if (col == 0) playerBidsYOffset = ++lastY;
+            }
+            playerFreeCashXOffset[col] = bidPerPlayerXOffset[col];
+
+            if (col == 0) {
+                playerFreeCashYOffset = ++lastY;
+                lowerPlayerCaptionYOffset = ++lastY;
+
+                fields = new JComponent[columnWidth * numberOfColumns][2 + lastY];
+                log.debug("Columns={} (width/col={} nbOfCol={}) rows={}", columnWidth * numberOfColumns,
+                        columnWidth, numberOfColumns, 2 + lastY);
+            }
+
+            addField(new Caption(LocalText.getText("ITEM")),
+                    itemNameXOffset[col], 0, 1, 2,
+            WIDE_LEFT + WIDE_RIGHT + WIDE_BOTTOM);
+
+            if (showBasePrices) {
+                addField(new Caption(LocalText.getText(includeBidding == StartRound.Bidding.ON_ITEMS
+                                ? "BASE_PRICE" : "PRICE")), basePriceXOffset[col], 0, 1, 2,
+                        WIDE_BOTTOM);
+            }
+            if (includeBidding == StartRound.Bidding.ON_ITEMS) {
+                addField(new Caption(LocalText.getText("MINIMUM_BID")),
+                        minBidXOffset[col], 0, 1, 2, WIDE_BOTTOM + WIDE_RIGHT);
+            }
+            addField(new Caption(LocalText.getText("PLAYERS")),
+                    playerCaptionXOffset[col], 0, np, 1, 0);
+            for (int i = 0; i < np; i++) {
+                upperPlayerCaption[col][i] = new Field(players.getPlayerByPosition(i).getPlayerNameModel());
+                addField(upperPlayerCaption[col][i], playerCaptionXOffset[col] + i,
+                        upperPlayerCaptionYOffset, 1, 1, WIDE_BOTTOM);
+            }
         }
-        playerFreeCashXOffset = bidPerPlayerXOffset;
-        playerFreeCashYOffset = ++lastY;
 
-        lowerPlayerCaptionYOffset = ++lastY;
-
-        fields = new JComponent[1 + infoXOffset][2 + lastY];
-
-        addField(new Caption(LocalText.getText("ITEM")), 0, 0, 1, 2,
-                WIDE_RIGHT + WIDE_BOTTOM);
-        if (showBasePrices) {
-            addField(new Caption(LocalText.getText(includeBidding == StartRound.Bidding.ON_ITEMS
-                            ? "BASE_PRICE" : "PRICE")), basePriceXOffset, 0, 1, 2,
-                    WIDE_BOTTOM);
-        }
-        if (includeBidding == StartRound.Bidding.ON_ITEMS) {
-            addField(new Caption(LocalText.getText("MINIMUM_BID")),
-                    minBidXOffset, 0, 1, 2, WIDE_BOTTOM + WIDE_RIGHT);
-        }
-        addField(new Caption(LocalText.getText("PLAYERS")),
-                playerCaptionXOffset, 0, np, 1, 0);
-        for (int i = 0; i < np; i++) {
-            upperPlayerCaption[i] = new Field(players.getPlayerByPosition(i).getPlayerNameModel());
-            addField(upperPlayerCaption[i], playerCaptionXOffset + i, upperPlayerCaptionYOffset, 1, 1, WIDE_BOTTOM);
-        }
-
+        int row, col;
         for (int i = 0; i < ni; i++) {
             final StartItem si = round.getStartItem(i);
 
-            itemName[i] = new Caption(si.getId());
-            HexHighlightMouseListener.addMouseListener(itemName[i], gameUIManager.getORUIManager(), si);
-            addField(itemName[i], itemNameXOffset, itemNameYOffset + i, 1, 1, WIDE_RIGHT);
+            if (multipleColumns) {
+                row = si.getRow() - 1;
+                col = si.getColumn() - 1;
+            } else {
+                row = i;
+                col = 0;
+            }
 
-            itemNameButton[i] = new ClickField(si.getId(), "", "", this, itemGroup);
+            itemName[i] = new Caption(si.getDisplayName());
+            HexHighlightMouseListener.addMouseListener(itemName[i], gameUIManager.getORUIManager(), si);
+            addField(itemName[i], itemNameXOffset[col], itemNameYOffset + row,
+                    1, 1, WIDE_LEFT + WIDE_RIGHT);
+
+            itemNameButton[i] = new ClickField(si.getDisplayName(), "", "", this, itemGroup);
             HexHighlightMouseListener.addMouseListener(itemNameButton[i], gameUIManager.getORUIManager(), si);
-            addField(itemNameButton[i], itemNameXOffset, itemNameYOffset + i, 1, 1, WIDE_RIGHT);
+            addField(itemNameButton[i], itemNameXOffset[col], itemNameYOffset + row,
+                    1, 1, WIDE_LEFT + WIDE_RIGHT);
 
             // Prevent row height resizing after every buy action
             itemName[i].setPreferredSize(itemNameButton[i].getPreferredSize());
 
             if (showBasePrices) {
                 basePrice[i] = new Field(si.getBasePriceModel());
-                addField(basePrice[i], basePriceXOffset, basePriceYOffset + i, 1, 1, 0);
+                addField(basePrice[i], basePriceXOffset[col], basePriceYOffset + row,
+                        1, 1, 0);
             }
 
             if (includeBidding == StartRound.Bidding.ON_ITEMS) {
                 minBid[i] = new Field(round.getMinimumBidModel(i));
-                addField(minBid[i], minBidXOffset, minBidYOffset + i, 1, 1, WIDE_RIGHT);
+                addField(minBid[i], minBidXOffset[col], minBidYOffset + row,
+                        1, 1, WIDE_RIGHT);
             }
 
             for (int j = 0; j < np; j++) {
                 bidPerPlayer[i][j] = new Field(round.getBidModel(i, players.getPlayerByPosition(j)));
-                addField(bidPerPlayer[i][j], bidPerPlayerXOffset + j, bidPerPlayerYOffset + i, 1, 1, 0);
+                addField(bidPerPlayer[i][j], bidPerPlayerXOffset[col] + j, bidPerPlayerYOffset + row,
+                        1, 1, 0);
             }
 
             info[i] = new Field(infoIcon);
-            //info[i].setToolTipText(getStartItemDescription(si));
+
             Certificate cert = si.getPrimary();
             Company comp = null;
             if (cert instanceof PublicCertificate) {
@@ -330,7 +389,7 @@ public class StartRoundWindow extends JFrame implements ActionListener, KeyListe
                     "<html>" + comp.getType().getId() + " company: ");
             info[i].setToolTipText(infoText);
             HexHighlightMouseListener.addMouseListener(info[i], gameUIManager.getORUIManager(), si);
-            addField(info[i], infoXOffset, infoYOffset + i, 1, 1, WIDE_LEFT);
+            addField(info[i], infoXOffset[col], infoYOffset + row, 1, 1, WIDE_LEFT + WIDE_RIGHT);
 
             // Invisible field, only used to hold current item status.
             itemStatus[i] = new Field(si.getStatusModel());
@@ -339,11 +398,13 @@ public class StartRoundWindow extends JFrame implements ActionListener, KeyListe
         // Player money
         boolean firstBelowTable = true;
         if (includeBidding != StartRound.Bidding.NO) {
-            addField(new Caption(LocalText.getText("BID")), playerBidsXOffset - 1, playerBidsYOffset, 1, 1, WIDE_TOP + WIDE_RIGHT);
+            addField(new Caption(LocalText.getText("BID")), playerBidsXOffset[0] - 1, playerBidsYOffset,
+                    1, 1, WIDE_TOP + WIDE_RIGHT);
 
             for (int i = 0; i < np; i++) {
                 playerBids[i] = new Field(round.getBlockedCashModel(players.getPlayerByPosition(i)));
-                addField(playerBids[i], playerBidsXOffset + i, playerBidsYOffset, 1, 1, WIDE_TOP);
+                addField(playerBids[i], playerBidsXOffset[0] + i, playerBidsYOffset,
+                        1, 1, WIDE_TOP);
             }
 
             firstBelowTable = false;
@@ -351,18 +412,18 @@ public class StartRoundWindow extends JFrame implements ActionListener, KeyListe
 
         addField(new Caption(
                         LocalText.getText(includeBidding != StartRound.Bidding.NO ? "FREE" : "CASH")),
-                playerFreeCashXOffset - 1, playerFreeCashYOffset, 1, 1,
+                playerFreeCashXOffset[0] - 1, playerFreeCashYOffset, 1, 1,
                 WIDE_RIGHT + (firstBelowTable ? WIDE_TOP : 0));
         for (int i = 0; i < np; i++) {
             playerFree[i] = new Field(includeBidding != StartRound.Bidding.NO
                     ? round.getFreeCashModel(players.getPlayerByPosition(i))
                     : players.getPlayerByPosition(i).getWallet());
-            addField(playerFree[i], playerFreeCashXOffset + i, playerFreeCashYOffset, 1, 1, firstBelowTable ? WIDE_TOP : 0);
+            addField(playerFree[i], playerFreeCashXOffset[0] + i, playerFreeCashYOffset, 1, 1, firstBelowTable ? WIDE_TOP : 0);
         }
 
         for (int i = 0; i < np; i++) {
             lowerPlayerCaption[i] = new Field(players.getPlayerByPosition(i).getPlayerNameModel());
-            addField(lowerPlayerCaption[i], playerFreeCashXOffset + i, playerFreeCashYOffset + 1, 1, 1, WIDE_TOP);
+            addField(lowerPlayerCaption[i], playerFreeCashXOffset[0] + i, playerFreeCashYOffset + 1, 1, 1, WIDE_TOP);
         }
 
         dummyButton = new ClickField("", "", "", this, itemGroup);
@@ -722,13 +783,13 @@ public class StartRoundWindow extends JFrame implements ActionListener, KeyListe
     }
 
     public void setSRPlayerTurn() {
+        int playerIndex = players.getCurrentPlayer().getIndex();
         for (int i = 0; i < players.getNumberOfPlayers(); i++) {
-            upperPlayerCaption[i].setHighlight(false);
-            lowerPlayerCaption[i].setHighlight(false);
+            for (int j = 0; j < numberOfColumns; j++) {
+                upperPlayerCaption[j][i].setHighlight(i == playerIndex);
+            }
+            lowerPlayerCaption[i].setHighlight(i == playerIndex);
         }
-
-        upperPlayerCaption[players.getCurrentPlayer().getIndex()].setHighlight(true);
-        lowerPlayerCaption[players.getCurrentPlayer().getIndex()].setHighlight(true);
     }
 
     private void setItemNameButton(int i, boolean clickable) {
@@ -807,6 +868,9 @@ public class StartRoundWindow extends JFrame implements ActionListener, KeyListe
     }
 
     public void updatePlayerOrder(List<String> newPlayerNames) {
+
+        // Multiple columns are here ignored for now.
+        // When is this called?
         int np = players.getNumberOfPlayers();
 
         int[] xref = new int[np];
@@ -822,18 +886,20 @@ public class StartRoundWindow extends JFrame implements ActionListener, KeyListe
         GridBagConstraints[] constraints = new GridBagConstraints[np];
         JComponent f;
         for (int y = upperPlayerCaptionYOffset; y <= lowerPlayerCaptionYOffset; y++) {
-            for (int i = 0, x = playerCaptionXOffset; i < np; i++, x++) {
+            for (int i = 0, x = playerCaptionXOffset[0]; i < np; i++, x++) {
                 cells[i] = fields[x][y];
                 constraints[i] = gb.getConstraints(cells[i]);
                 statusPanel.remove(cells[i]);
             }
-            for (int i = 0, x = playerCaptionXOffset; i < np; i++, x++) {
+            for (int i = 0, x = playerCaptionXOffset[0]; i < np; i++, x++) {
                 f = fields[x][y] = cells[xref[i]];
                 statusPanel.add(f, constraints[i]);
             }
         }
-        for (int i = 0, x = playerCaptionXOffset; i < np; i++, x++) {
-            upperPlayerCaption[i] = (Field) fields[x][upperPlayerCaptionYOffset];
+        for (int i = 0, x = playerCaptionXOffset[0]; i < np; i++, x++) {
+            for (int col = 0; col < numberOfColumns; col++) {
+                upperPlayerCaption[col][i] = (Field) fields[x][upperPlayerCaptionYOffset];
+            }
             lowerPlayerCaption[i] = (Field) fields[x][lowerPlayerCaptionYOffset];
         }
 

--- a/src/main/resources/data/1835/CompanyManager.xml
+++ b/src/main/resources/data/1835/CompanyManager.xml
@@ -230,25 +230,26 @@
 	</Company>
 	
 	<StartPacket roundClass="net.sf.rails.game.specific._1835.StartRound_1835" variant="Snake">
-		<Item name="NF"		type="Private" basePrice="100" row="1">
+		<MultipleColumns/>
+		<Item name="NF"		type="Private" basePrice="100" row="1" column="1" displayName="NF+By">
 			<SubItem name="Bay" type="Major"/>
 		</Item>
-		<Item name="M1"		type="Minor" basePrice="80" row="2"/>
-		<Item name="LD"		type="Private" basePrice="190" row="2">
+		<Item name="M1"		type="Minor" basePrice="80" row="2" column="1"/>
+		<Item name="LD"		type="Private" basePrice="190" row="2" column="2" displayName="LD+SxP">
 			<SubItem name="Sax" type="Major" president="yes"/>
 		</Item>
-		<Item name="M2"		type="Minor" basePrice="170" row="2"/>
-		<Item name="M3"		type="Minor" basePrice="80" row="3"/>
-		<Item name="M4"		type="Minor" basePrice="160" row="3"/>
-		<Item name="Bay"	type="Major" president="yes" basePrice="184" row="3"/>
-		<Item name="BB"		type="Private" basePrice="130" row="3"/>
-		<Item name="HB"		type="Private" basePrice="160" row="4"/>
-		<Item name="M5"		type="Minor" basePrice="80" row="4"/>
-		<Item name="M6"		type="Minor" basePrice="80" row="4"/>
-		<Item name="OBB"	type="Private" basePrice="120" row="4">
+		<Item name="M2"		type="Minor" basePrice="170" row="2" column="3"/>
+		<Item name="M3"		type="Minor" basePrice="80" row="3" column="1"/>
+		<Item name="M4"		type="Minor" basePrice="160" row="3" column="2"/>
+		<Item name="Bay"	type="Major" president="yes" basePrice="184" row="3" column="3"/>
+		<Item name="BB"		type="Private" basePrice="130" row="3" column="4"/>
+		<Item name="HB"		type="Private" basePrice="160" row="4" column="1"/>
+		<Item name="M5"		type="Minor" basePrice="80" row="4" column="2"/>
+		<Item name="M6"		type="Minor" basePrice="80" row="4" column="3"/>
+		<Item name="OBB"	type="Private" basePrice="120" row="4" column="4" displayName="OBB+By">
 			<SubItem name="Bay" type="Major"/>
 		</Item>
-		<Item name="PfB"	type="Private" basePrice="150" row="4">
+		<Item name="PfB"	type="Private" basePrice="150" row="4" column="5" displayName="PfB+By">
 			<SubItem name="Bay" type="Major"/>
 		</Item>
 	</StartPacket>

--- a/src/main/resources/data/1837/CompanyManager.xml
+++ b/src/main/resources/data/1837/CompanyManager.xml
@@ -401,31 +401,32 @@
     </IfOption>
     <IfOption name="Variant" value="Basegame,Romoth">
         <StartPacket name="Coal Mines" roundClass="net.sf.rails.game.specific._1837.StartRound_1837_Coal">
+            <MultipleColumns/>
             <Item name="EKT" type="Coal" basePrice="100" column="1" row="1"/>
             <Item name="EPP" type="Coal" basePrice="100" column="2" row="1"/>
             <Item name="BB" type="Coal" basePrice="100" column="3" row="1"/>
             <Item name="EOD" type="Coal" basePrice="100" column="1" row="2"/>
             <Item name="RGTE" type="Coal" basePrice="100" column="2" row="2"/>
-            <Item name="SmB" type="Private" basePrice="150" column="3" row="2">
+            <Item name="SmB" type="Private" basePrice="150" column="3" row="2" displayName="SmB+S1">
                 <SubItem name="S1" type="Minor1"/>
             </Item>
-            <Item name="KwB" type="Private" basePrice="170" column="1" row="3">
+            <Item name="KwB" type="Private" basePrice="170" column="1" row="3" displayName="KwB+S2">
                 <SubItem name="S2" type="Minor1"/>
             </Item>
-            <Item name="AB" type="Private" basePrice="185" column="2" row="3">
+            <Item name="AB" type="Private" basePrice="185" column="2" row="3" displayName="AB+S3">
                 <SubItem name="S3" type="Minor1"/>
             </Item>
             <Item name="SPB" type="Coal" basePrice="100" column="3" row="3"/>
             <Item name="MLB" type="Coal" basePrice="100" column="1" row="4"/>
             <Item name="EHS" type="Coal" basePrice="100" column="2" row="4"/>
             <Item name="ZKB" type="Coal" basePrice="100" column="3" row="4"/>
-            <Item name="BrB" type="Private" basePrice="140" column="1" row="5">
+            <Item name="BrB" type="Private" basePrice="140" column="1" row="5" displayName="BrB+S4">
                 <SubItem name="S4" type="Minor1"/>
             </Item>
             <Item name="LRB" type="Coal" basePrice="100" column="2" row="5"/>
             <Item name="TB" type="Private" basePrice="150" column="3" row="5"/>
             <Item name="WB" type="Private" basePrice="130" column="1" row="6"/>
-            <Item name="KB" type="Private" basePrice="120" column="2" row="6">
+            <Item name="KB" type="Private" basePrice="120" column="2" row="6" displayName="KB+S5">
                 <SubItem name="S5" type="Minor1"/>
             </Item>
         </StartPacket>
@@ -460,26 +461,26 @@
             <Item name="BB" type="Coal" basePrice="40"/>
             <Item name="EOD" type="Coal" basePrice="40"/>
             <Item name="RGTE" type="Coal" basePrice="40"/>
-            <Item name="SmB" type="Private" basePrice="100">
+            <Item name="SmB" type="Private" basePrice="100" displayName="SmB+S1">
                 <SubItem name="S1" type="Minor1"/>
             </Item>
-            <Item name="KwB" type="Private" basePrice="120">
+            <Item name="KwB" type="Private" basePrice="120" displayName="KwB+S2">
                 <SubItem name="S2" type="Minor1"/>
             </Item>
-            <Item name="AB" type="Private" basePrice="135">
+            <Item name="AB" type="Private" basePrice="135" displayName="AB+S3">
                 <SubItem name="S3" type="Minor1"/>
             </Item>
             <Item name="SPB" type="Coal" basePrice="40"/>
             <Item name="MLB" type="Coal" basePrice="40"/>
             <Item name="EHS" type="Coal" basePrice="40"/>
             <Item name="ZKB" type="Coal" basePrice="40"/>
-            <Item name="BrB" type="Private" basePrice="90">
+            <Item name="BrB" type="Private" basePrice="90" displayName="Brb+S4">
                 <SubItem name="S4" type="Minor1"/>
             </Item>
             <Item name="LRB" type="Coal" basePrice="40"/>
             <Item name="TB" type="Private" basePrice="80"/>
             <Item name="WB" type="Private" basePrice="50"/>
-            <Item name="KB" type="Private" basePrice="70">
+            <Item name="KB" type="Private" basePrice="70" displayName="KB+S5">
                 <SubItem name="S5" type="Minor1"/>
             </Item>
             <Item name="K1" type="Minor1" basePrice="60"/>

--- a/src/main/resources/data/1837/Game.xml
+++ b/src/main/resources/data/1837/Game.xml
@@ -1,225 +1,220 @@
 <?xml version="1.0"?>
 <ComponentManager>
-        <Component name="GameManager" class="net.sf.rails.game.specific._1837.GameManager_1837">
-                <Game name="1837"/>
-                <GameParameters>
-                        <PlayerShareLimit percentage="60"/>
-                        <BankPoolLimit percentage="50"/>
-                        <StockRound class="net.sf.rails.game.specific._1837.StockRound_1837"
-                                sequence="SellBuySell">
-                                <NoSaleInFirstSR/>
-                                <NoSaleIfNotOperated/>
-                        </StockRound>
-                        <OperatingRound class="net.sf.rails.game.specific._1837.OperatingRound_1837">
-                                <EmergencyTrainBuying mustBuyCheapestTrain="no" mayAlwaysBuyNewTrain="yes" mayBuyFromCompany="yes"/>
-                                <RevenueIncrement amount="5"/>
-                        </OperatingRound>
-                </GameParameters>
-                <GuiClasses>
-                	<GameStatus	class="net.sf.rails.ui.swing.gamespecific._1837.GameStatus_1837"/>
-		         <IfOption name="Variant" value="Basegame,Romoth"> --> 
-                    <StartRoundWindow class="net.sf.rails.ui.swing.gamespecific._1837.StartRoundWindow_1837"/>
-				</IfOption>  
-                 <IfOption name="Variant" value="1837-2ndEd."> -->
-                    <StartRoundWindow class="net.sf.rails.ui.swing.gamespecific._1837.StartRoundWindow_1837_2ndED"/>
-					 </IfOption> 
-                    <StatusWindow class="net.sf.rails.ui.swing.gamespecific._1837.StatusWindow_1837"/>
-                    <GameUIManager class="net.sf.rails.ui.swing.gamespecific._1837.GameUIManager_1837"/>
-                    <ORUIManager class="net.sf.rails.ui.swing.gamespecific._1837.ORUIManager_1837"/>
-                </GuiClasses>
-                <EndOfGame>
-                        <BankBreaks limit="0" finish="currentOR"/>
-                        <!-- "Runs out"; when "broken", -1 is the limit -->
-                </EndOfGame>
-        </Component>
-        <Component name="PlayerManager" class="net.sf.rails.game.PlayerManager">
-                <Players number="3" cash="730" certLimit="28"/>
-                <Players number="4" cash="555" certLimit="21"/>
-                <Players number="5" cash="450" certLimit="17"/>
-                <Players number="6" cash="380" certLimit="14"/>
-                <Players number="7" cash="330" certLimit="12"/>
-        </Component>
-        <Component name="Bank" class="net.sf.rails.game.financial.Bank">
-                <Bank amount="14268"/>
-                <Money format="@K"/>
-        </Component>
-        <Component name="TileManager" class="net.sf.rails.game.TileManager"
-                file="TileSet.xml"/>
-        <Component name="Map" class="net.sf.rails.game.MapManager" file="Map.xml"/>
-        <Component name="CompanyManager" class="net.sf.rails.game.CompanyManager"
-                file="CompanyManager.xml"/>
-        <Component name="StockMarket" class="net.sf.rails.game.specific._1837.StockMarket_1837"
-                file="StockMarket.xml"/>
-        <Component name="TrainManager" class="net.sf.rails.game.TrainManager">
-                <Defaults>
-                        <Reach base="stops" countTowns="yes"/>
-                        <Score towns="yes"/>
-                </Defaults>
-                <TrainType name="2" majorStops="2" cost="90" quantity="14"
-                                alsoReleased="1G"/>
-                <TrainType name="3" majorStops="3" cost="180" quantity="5">
-                        <NewPhase phaseName="3"/>
-                </TrainType>
-                <TrainType name="3+1" majorStops="3" minorStops="1" cost="280" quantity="2">
-                        <NewPhase phaseName="3+1"/>
-                </TrainType>
-                <TrainType name="4" majorStops="4" cost="470" quantity="4">
-                        <NewPhase phaseName="4"/>
-                </TrainType>
-                <TrainType name="4E" majorStops="4" cost="500" quantity="1">
-                        <Reach countTowns="no"/>
-                        <Score towns="no"/>
-                        <NewPhase phaseName="4E"/>
-                </TrainType>
-                <TrainType name="4+1" majorStops="4" minorStops="1" cost="530" quantity="1">
-                        <NewPhase phaseName="4+1"/>
-                </TrainType>
-                <TrainType name="4+2" majorStops="4" minorStops="2" cost="560" quantity="1"/>
-                <TrainType name="5" majorStops="5" cost="800" quantity="2">
-                        <NewPhase phaseName="5"/>
-                </TrainType>
-                <TrainType name="5E" majorStops="5" cost="830" quantity="1">
-                        <Reach countTowns="no"/>
-                        <Score towns="no"/>
-                </TrainType>
-                <TrainType name="5+2" majorStops="5" minorStops="2" cost="860" quantity="1">
-                        <NewPhase phaseName="5+2"/>
-                </TrainType>
-                <TrainType name="5+3" majorStops="5" minorStops="3" cost="900" quantity="1"/>
-                <TrainType name="5+4" majorStops="5" minorStops="4" cost="960" quantity="1">
-                        <IfOption name="UnlimitedTopTrains" value="Yes">
-                                <Attributes quantity="-1"/>
-                        </IfOption>
-                </TrainType>
-                <!-- These G-train specs have been moved to the end, because these
-                do not follow the normal train sequence rules, and interrupted the
-                normal passenger train progress (2G was blocking 3+1 to be release
-                after the last 3 was bought. Only the 1G had to be kept at the top,
-                to prevent its first buy being undone behind the scenes by ) -->
-                <TrainType name="1G" category="goods" majorStops="1" cost="100" quantity="10">
-                        <Reach countTowns="no"/>
-                        <Score towns="yes"/>
-                        <!--NewPhase phaseName="2"/ -->
-                </TrainType>
-                <TrainType name="2G" category="goods" majorStops="2" cost="230" quantity="6">
-                        <Reach countTowns="no"/>
-                        <Score towns="yes"/>
-                </TrainType>
-                <TrainType name="3G" category="goods" majorStops="3" cost="590" quantity="2">
-                        <Reach countTowns="no"/>
-                        <Score towns="yes"/>
-                        <NewPhase phaseName="3G"/>
-                </TrainType>
-                <TrainType name="4G" category="goods" majorStops="4" cost="1000" quantity="3">
-                        <Reach countTowns="no"/>
-                        <Score towns="yes"/>
-                        <NewPhase phaseName="4G"/>
-                        <IfOption name="UnlimitedTopTrains" value="Yes">
-                                <Attributes quantity="-1"/>
-                        </IfOption>
-                </TrainType>
-                <!-- TBD: Add support for 1837's trade-in rule, which says a
-                     company that is at its train limit may trade in any train
-                     to the bank pool for half face value, but only if that
-                     company then replaces it by buying another train.
-                     (However, companies that get "caught" when the train limit
-                     falls must still discard one without compensation.) -->
-                <!-- TBD: Another rule that needs to be enforced in 1837: If
-                     minor or coal company A merges into major company B and
-                     causes B to exceed its train limit, any trains discarded
-                     must be from A, even if they are better than B's own. -->
-        </Component>
-        <Component name="PhaseManager" class="net.sf.rails.game.PhaseManager">
-                <Phase name="2" realName="1">
-                        <Tiles colour="yellow"/>
-                        <OperatingRounds number="1"/>
-                </Phase>
-                <Phase name="3" realName="2">
-                        <Tiles colour="yellow,green"/>
-                        <Trains tradingAllowed="yes" limitStep="2" released="2G"/>
-                        <!-- TBD: Private companies no longer block tile-laying
-                                  in their hex by other players. -->
-                        <!-- Open Bosnia-Herzegovina for building: -->
-                        <LayTile hex="L16" tile="0"/>
-                        <LayTile hex="L18" tile="-1"/>
-                        <LayTile hex="L20" tile="0"/>
-                        <LayTile hex="M17" tile="0" cost="70"/>
-                        <LayTile hex="M19" tile="0" cost="70"/>
-                        <LayTile hex="M21" tile="0" cost="70"/>
-                        <LayTile hex="N18" tile="0" cost="70"/>
-                        <LayTile hex="N20" tile="-10" city="Sarajevo"/>
-                        <OperatingRounds number="2"/>
-                </Phase>
-                <Phase name="3+1" realName="2">
-                        <Trains limitStep="3"/>
-                </Phase>
-                <Phase name="4" realName="2">
-                        <Trains rusted="2" released="3G"/>
-                        <!-- Clear out Italy, make it off-limits, and place
-                             green tile 426 on Bozen: -->
-                        <LayTile hex="K4" tile="-37004" removeToken="yes"/>
-                        <LayTile hex="K6" tile="426" orientation="3"/>
-                        <LayTile hex="K8" tile="-37004" removeToken="yes"/>
-                        <LayTile hex="K10" tile="-37004" removeToken="yes"/>
-                        <LayTile hex="L3" tile="-37004" removeToken="yes"/>
-                        <LayTile hex="L5" tile="-37004" removeToken="yes"/>
-                        <LayTile hex="L7" tile="-37004" removeToken="yes"/>
-                        <LayTile hex="L9" tile="-37004" removeToken="yes"/>
-                        <LayTile hex="M4" tile="-37004" removeToken="yes"/>
-                        <LayTile hex="M6" tile="-37004" removeToken="yes"/>
-                        <LayTile hex="M8" tile="-37004" removeToken="yes"/>
-                        <!-- TBD: S1-S5 must all convert, forming Sd. -->
-                        <!-- TBD: K1 may convert, forming KK.  If it doesn't, it
-                                  gets the option again at the start of each
-                                  round.  If and when K1 converts, then K2-K3
-                                  get the option to convert, and get it again at
-                                  the start of each round until forced to
-                                  convert upon the first 4+1 train purchase. -->
-                </Phase>
-                <Phase name="3G" realName="2">
-                        <Trains rusted="1G"/>
-                </Phase>
-                <Phase name="4E" realName="2">
-                        <!-- TBD: U1 director may convert, forming Ug.  If he
-                                  doesn't, he gets the option again at the start
-                                  of each round.  If and when U1 converts, then
-                                  U2-U3 directors get the option to convert, and
-                                  get it again (after KK) at the start of each
-                                  round until forced to convert upon the first
-                                  5 train purchase.  Non-director shareholders
-                                  of U1 and U3 have no choice, they convert when
-                                  the director of that minor converts. -->
-                </Phase>
-                <Phase name="4+1" realName="2">
-                        <!-- TBD: K1-K3 must all convert, forming KK, if they
-                                  haven't already. -->
-                </Phase>
-                <Phase name="5" realName="3">
-                        <Tiles colour="yellow,green,brown"/>
-                        <Trains rusted="3" limitStep="4" released="4G"/>
-                        <!--Privates close="yes"/-->
-                        <Info key="PhaseClosesAllPrivates"/>
-                        <!-- TBD: U1-U3 must all convert, forming Ug, if they
-                                  haven't already. -->
-                        <!-- TBD: All coal companies must convert even if their
-                                  major companies haven't formed. -->
-                        <OffBoardRevenue step="2"/> <!--  Where do we read that..  -->
-                        <!-- EV: should be renamed to PhaseDependentRevenue -->
-                        <OperatingRounds number="3"/>
-                </Phase>
-                <Phase name="4G" realName="3">
-                        <Trains rusted="2G"/>
-                </Phase>
-                <Phase name="5+2" realName="3">
-                        <Trains rusted="3+1"/>
-                </Phase>
-        </Component>
-        <Component name="RevenueManager" class="net.sf.rails.algorithms.RevenueManager">
-				<Modifier class="net.sf.rails.game.specific._1837.ItalyTileModifier" />
-				<Modifier class="net.sf.rails.game.specific._1837.BzHTileModifier" />
-				<Modifier class="net.sf.rails.game.specific._1837.RunToCoalMineModifier"/>
-				<!-- <Modifier class="net.sf.rails.game.specific._1837.CoalTrainModifier"/>
-				Not sure why the above modifier was outcommented, I have replaced it anyway. -->
-        </Component>
+    <Component name="GameManager" class="net.sf.rails.game.specific._1837.GameManager_1837">
+        <Game name="1837"/>
+        <GameParameters>
+            <PlayerShareLimit percentage="60"/>
+            <BankPoolLimit percentage="50"/>
+            <StockRound class="net.sf.rails.game.specific._1837.StockRound_1837"
+                        sequence="SellBuySell">
+                <NoSaleInFirstSR/>
+                <NoSaleIfNotOperated/>
+            </StockRound>
+            <OperatingRound class="net.sf.rails.game.specific._1837.OperatingRound_1837">
+                <EmergencyTrainBuying mustBuyCheapestTrain="no" mayAlwaysBuyNewTrain="yes" mayBuyFromCompany="yes"/>
+                <RevenueIncrement amount="5"/>
+            </OperatingRound>
+        </GameParameters>
+        <GuiClasses>
+            <GameStatus class="net.sf.rails.ui.swing.gamespecific._1837.GameStatus_1837"/>
+            <StartRoundWindow class="net.sf.rails.ui.swing.gamespecific._1837.StartRoundWindow_1837"/>
+            <StatusWindow class="net.sf.rails.ui.swing.gamespecific._1837.StatusWindow_1837"/>
+            <GameUIManager class="net.sf.rails.ui.swing.gamespecific._1837.GameUIManager_1837"/>
+            <ORUIManager class="net.sf.rails.ui.swing.gamespecific._1837.ORUIManager_1837"/>
+        </GuiClasses>
+        <EndOfGame>
+            <BankBreaks limit="0" finish="currentOR"/>
+            <!-- "Runs out"; when "broken", -1 is the limit -->
+        </EndOfGame>
+    </Component>
+    <Component name="PlayerManager" class="net.sf.rails.game.PlayerManager">
+        <Players number="3" cash="730" certLimit="28"/>
+        <Players number="4" cash="555" certLimit="21"/>
+        <Players number="5" cash="450" certLimit="17"/>
+        <Players number="6" cash="380" certLimit="14"/>
+        <Players number="7" cash="330" certLimit="12"/>
+    </Component>
+    <Component name="Bank" class="net.sf.rails.game.financial.Bank">
+        <Bank amount="14268"/>
+        <Money format="@K"/>
+    </Component>
+    <Component name="TileManager" class="net.sf.rails.game.TileManager"
+               file="TileSet.xml"/>
+    <Component name="Map" class="net.sf.rails.game.MapManager" file="Map.xml"/>
+    <Component name="CompanyManager" class="net.sf.rails.game.CompanyManager"
+               file="CompanyManager.xml"/>
+    <Component name="StockMarket" class="net.sf.rails.game.specific._1837.StockMarket_1837"
+               file="StockMarket.xml"/>
+    <Component name="TrainManager" class="net.sf.rails.game.TrainManager">
+        <Defaults>
+            <Reach base="stops" countTowns="yes"/>
+            <Score towns="yes"/>
+        </Defaults>
+        <TrainType name="2" majorStops="2" cost="90" quantity="14"
+                   alsoReleased="1G"/>
+        <TrainType name="3" majorStops="3" cost="180" quantity="5">
+            <NewPhase phaseName="3"/>
+        </TrainType>
+        <TrainType name="3+1" majorStops="3" minorStops="1" cost="280" quantity="2">
+            <NewPhase phaseName="3+1"/>
+        </TrainType>
+        <TrainType name="4" majorStops="4" cost="470" quantity="4">
+            <NewPhase phaseName="4"/>
+        </TrainType>
+        <TrainType name="4E" majorStops="4" cost="500" quantity="1">
+            <Reach countTowns="no"/>
+            <Score towns="no"/>
+            <NewPhase phaseName="4E"/>
+        </TrainType>
+        <TrainType name="4+1" majorStops="4" minorStops="1" cost="530" quantity="1">
+            <NewPhase phaseName="4+1"/>
+        </TrainType>
+        <TrainType name="4+2" majorStops="4" minorStops="2" cost="560" quantity="1"/>
+        <TrainType name="5" majorStops="5" cost="800" quantity="2">
+            <NewPhase phaseName="5"/>
+        </TrainType>
+        <TrainType name="5E" majorStops="5" cost="830" quantity="1">
+            <Reach countTowns="no"/>
+            <Score towns="no"/>
+        </TrainType>
+        <TrainType name="5+2" majorStops="5" minorStops="2" cost="860" quantity="1">
+            <NewPhase phaseName="5+2"/>
+        </TrainType>
+        <TrainType name="5+3" majorStops="5" minorStops="3" cost="900" quantity="1"/>
+        <TrainType name="5+4" majorStops="5" minorStops="4" cost="960" quantity="1">
+            <IfOption name="UnlimitedTopTrains" value="Yes">
+                <Attributes quantity="-1"/>
+            </IfOption>
+        </TrainType>
+        <!-- These G-train specs have been moved to the end, because these
+        do not follow the normal train sequence rules, and interrupted the
+        normal passenger train progress (2G was blocking 3+1 to be release
+        after the last 3 was bought. Only the 1G had to be kept at the top,
+        to prevent its first buy being undone behind the scenes by ) -->
+        <TrainType name="1G" category="goods" majorStops="1" cost="100" quantity="10">
+            <Reach countTowns="no"/>
+            <Score towns="yes"/>
+            <!--NewPhase phaseName="2"/ -->
+        </TrainType>
+        <TrainType name="2G" category="goods" majorStops="2" cost="230" quantity="6">
+            <Reach countTowns="no"/>
+            <Score towns="yes"/>
+        </TrainType>
+        <TrainType name="3G" category="goods" majorStops="3" cost="590" quantity="2">
+            <Reach countTowns="no"/>
+            <Score towns="yes"/>
+            <NewPhase phaseName="3G"/>
+        </TrainType>
+        <TrainType name="4G" category="goods" majorStops="4" cost="1000" quantity="3">
+            <Reach countTowns="no"/>
+            <Score towns="yes"/>
+            <NewPhase phaseName="4G"/>
+            <IfOption name="UnlimitedTopTrains" value="Yes">
+                <Attributes quantity="-1"/>
+            </IfOption>
+        </TrainType>
+        <!-- TBD: Add support for 1837's trade-in rule, which says a
+             company that is at its train limit may trade in any train
+             to the bank pool for half face value, but only if that
+             company then replaces it by buying another train.
+             (However, companies that get "caught" when the train limit
+             falls must still discard one without compensation.) -->
+        <!-- TBD: Another rule that needs to be enforced in 1837: If
+             minor or coal company A merges into major company B and
+             causes B to exceed its train limit, any trains discarded
+             must be from A, even if they are better than B's own. -->
+    </Component>
+    <Component name="PhaseManager" class="net.sf.rails.game.PhaseManager">
+        <Phase name="2" realName="1">
+            <Tiles colour="yellow"/>
+            <OperatingRounds number="1"/>
+        </Phase>
+        <Phase name="3" realName="2">
+            <Tiles colour="yellow,green"/>
+            <Trains tradingAllowed="yes" limitStep="2" released="2G"/>
+            <!-- TBD: Private companies no longer block tile-laying
+                      in their hex by other players. -->
+            <!-- Open Bosnia-Herzegovina for building: -->
+            <LayTile hex="L16" tile="0"/>
+            <LayTile hex="L18" tile="-1"/>
+            <LayTile hex="L20" tile="0"/>
+            <LayTile hex="M17" tile="0" cost="70"/>
+            <LayTile hex="M19" tile="0" cost="70"/>
+            <LayTile hex="M21" tile="0" cost="70"/>
+            <LayTile hex="N18" tile="0" cost="70"/>
+            <LayTile hex="N20" tile="-10" city="Sarajevo"/>
+            <OperatingRounds number="2"/>
+        </Phase>
+        <Phase name="3+1" realName="2">
+            <Trains limitStep="3"/>
+        </Phase>
+        <Phase name="4" realName="2">
+            <Trains rusted="2" released="3G"/>
+            <!-- Clear out Italy, make it off-limits, and place
+                 green tile 426 on Bozen: -->
+            <LayTile hex="K4" tile="-37004" removeToken="yes"/>
+            <LayTile hex="K6" tile="426" orientation="3"/>
+            <LayTile hex="K8" tile="-37004" removeToken="yes"/>
+            <LayTile hex="K10" tile="-37004" removeToken="yes"/>
+            <LayTile hex="L3" tile="-37004" removeToken="yes"/>
+            <LayTile hex="L5" tile="-37004" removeToken="yes"/>
+            <LayTile hex="L7" tile="-37004" removeToken="yes"/>
+            <LayTile hex="L9" tile="-37004" removeToken="yes"/>
+            <LayTile hex="M4" tile="-37004" removeToken="yes"/>
+            <LayTile hex="M6" tile="-37004" removeToken="yes"/>
+            <LayTile hex="M8" tile="-37004" removeToken="yes"/>
+            <!-- TBD: S1-S5 must all convert, forming Sd. -->
+            <!-- TBD: K1 may convert, forming KK.  If it doesn't, it
+                      gets the option again at the start of each
+                      round.  If and when K1 converts, then K2-K3
+                      get the option to convert, and get it again at
+                      the start of each round until forced to
+                      convert upon the first 4+1 train purchase. -->
+        </Phase>
+        <Phase name="3G" realName="2">
+            <Trains rusted="1G"/>
+        </Phase>
+        <Phase name="4E" realName="2">
+            <!-- TBD: U1 director may convert, forming Ug.  If he
+                      doesn't, he gets the option again at the start
+                      of each round.  If and when U1 converts, then
+                      U2-U3 directors get the option to convert, and
+                      get it again (after KK) at the start of each
+                      round until forced to convert upon the first
+                      5 train purchase.  Non-director shareholders
+                      of U1 and U3 have no choice, they convert when
+                      the director of that minor converts. -->
+        </Phase>
+        <Phase name="4+1" realName="2">
+            <!-- TBD: K1-K3 must all convert, forming KK, if they
+                      haven't already. -->
+        </Phase>
+        <Phase name="5" realName="3">
+            <Tiles colour="yellow,green,brown"/>
+            <Trains rusted="3" limitStep="4" released="4G"/>
+            <!--Privates close="yes"/-->
+            <Info key="PhaseClosesAllPrivates"/>
+            <!-- TBD: U1-U3 must all convert, forming Ug, if they
+                      haven't already. -->
+            <!-- TBD: All coal companies must convert even if their
+                      major companies haven't formed. -->
+            <OffBoardRevenue step="2"/> <!--  Where do we read that..  -->
+            <!-- EV: should be renamed to PhaseDependentRevenue -->
+            <OperatingRounds number="3"/>
+        </Phase>
+        <Phase name="4G" realName="3">
+            <Trains rusted="2G"/>
+        </Phase>
+        <Phase name="5+2" realName="3">
+            <Trains rusted="3+1"/>
+        </Phase>
+    </Component>
+    <Component name="RevenueManager" class="net.sf.rails.algorithms.RevenueManager">
+        <Modifier class="net.sf.rails.game.specific._1837.ItalyTileModifier"/>
+        <Modifier class="net.sf.rails.game.specific._1837.BzHTileModifier"/>
+        <Modifier class="net.sf.rails.game.specific._1837.RunToCoalMineModifier"/>
+        <!-- <Modifier class="net.sf.rails.game.specific._1837.CoalTrainModifier"/>
+        Not sure why the above modifier was outcommented, I have replaced it anyway. -->
+    </Component>
 </ComponentManager>
 

--- a/src/main/resources/data/1837/TileSet.xml
+++ b/src/main/resources/data/1837/TileSet.xml
@@ -49,13 +49,13 @@
                 <Upgrade id="434"/>
         </Tile>
         <Tile id="-37010"><!-- yellow Buda/Pest -->
-                <Upgrade id="425" relayBaseTokens="yes"/>
+                <Upgrade id="425"/>
         </Tile>
         <Tile id="-37011"><!-- yellow Marburg -->
                 <Upgrade id="5,57"/>
         </Tile>
         <Tile id="-37012"><!-- yellow Wien -->
-                <Upgrade id="427" relayBaseTokens="yes"/>
+                <Upgrade id="427"/>
         </Tile>
         <Tile id="-37103"><!-- Preprinted yellow tile 3 -->
                 <Upgrade id="416,417,422,423"/>

--- a/src/main/resources/data/GamesList.xml
+++ b/src/main/resources/data/GamesList.xml
@@ -222,8 +222,7 @@ Published 2004 by Deep Thought Games, LLC
 			Known limitations:
 			- Buying the KK and Ug minors in subsequent Start rounds does not work well.
 			  These rounds should be changed to Stock Rounds.
-			- Multiple-city green upgrades often need tokens to be replaced manually.
-			- Not yet tested after the 3-train phase.
+			- Not yet tested beyond the 3-train phase.
 		</Description>
 		<Players minimum = "3" maximum = "7" />
 	</Game>


### PR DESCRIPTION
Fix:
- Tile upgrades that add stations (Vienna) no longer need manual token relay.

Novelties:
- Added <IfVariant value=...> tag, as a shorthand for <IfOption name="Variant" value=...>
- Added optional StartItem attribute displayName, to set a different name for display in the StartRoundWindow; e.g. "SmB+S1" in 1837. Also for 1835, e.g. "NF+By".
- Implemented start packet multi-column display. Applied to the 1835 and 1837 base games.